### PR TITLE
fix Arachnotron burst fire

### DIFF
--- a/src/i_main.c
+++ b/src/i_main.c
@@ -238,7 +238,7 @@ int I_GetControllerData(void)
 			last_joyy = -cont->joy2y * 2;
 		}
 
-    if (cont->joy2x > 10) {
+		if (cont->joy2x > 10) {
 			last_Rtrig = MAX(last_Rtrig, cont->joy2x * 4);
 			ret |= PAD_R_TRIG;
 		} else if (cont->joy2x < -10) {
@@ -246,7 +246,7 @@ int I_GetControllerData(void)
 			ret |= PAD_L_TRIG;
 		}
 
-    ret |= (last_joyy & 0xff);
+		ret |= (last_joyy & 0xff);
 		ret |= ((last_joyx & 0xff) << 8);
 
 		// ATTACK

--- a/src/p_enemy.c
+++ b/src/p_enemy.c
@@ -835,7 +835,14 @@ void A_SpidRefire(mobj_t *actor) // 80011CBC
 		return;
 	}
 
-	if (--actor->extradata <= 0) {
+	// was 	if (--actor->extradata <= 0) {
+	// extradata is void*
+	// that code gets compiled/optimized out of existence
+
+	// this fixes it
+	actor->extradata = (int*)((int)actor->extradata - 1);
+
+	if (actor->extradata <= 0) {
 		P_SetMobjState(actor, actor->info->missilestate);
 		actor->extradata = (int *)5;
 	}


### PR DESCRIPTION
There was an issue with how some code was being compiled/optimized.

This resolves it and restores the original burst fire behavior of Arachnotron attacks (5 shot bursts).