### PR TITLE
wrap single-node check in RANGECHECK compile guard (Doom 64 maps have…

### DIFF
--- a/src/r_main.c
+++ b/src/r_main.c
@@ -264,8 +264,10 @@ struct subsector_s *R_PointInSubsector(fixed_t x, fixed_t y)
 	node_t *node;
 	int side, nodenum;
 
+#if RANGECHECK
 	if (!numnodes) /* single subsector is a special case */
 		return subsectors;
+#endif
 
 	nodenum = numnodes - 1;
 


### PR DESCRIPTION
… minimum of 2 subsectors)