### PR TITLE
add graphics Quality selection to video menu

### DIFF
--- a/src/m_main.c
+++ b/src/m_main.c
@@ -117,6 +117,15 @@ char *ControlText[] = //8007517C
 #define M_TXT83 "ISANN KEKET" // [Immorpher] Credits
 #define M_TXT84 "NEVANDER" // [Immorpher] Credits
 
+#define M_TXT85 "Absolution"
+#define M_TXT86 "Lost Levels"
+#define M_TXT87 "KneeDeep In The Dead"
+
+#define M_TXT88 "Quality"
+#define M_TXT89 "Low"
+#define M_TXT90 "Medium"
+#define M_TXT91 "Ultra"
+
 char *MenuText[] = // 8005ABA0
 	{
 		M_TXT00, M_TXT01, M_TXT02, M_TXT03, M_TXT04, M_TXT05, M_TXT06,
@@ -132,6 +141,8 @@ char *MenuText[] = // 8005ABA0
 		M_TXT70, M_TXT71, M_TXT72, M_TXT73, M_TXT74, M_TXT75, M_TXT76,
 		M_TXT77, M_TXT78, M_TXT79, M_TXT80, M_TXT81, M_TXT82, M_TXT83,
 		M_TXT84,
+		M_TXT85, M_TXT86, M_TXT87,
+		M_TXT88, M_TXT89, M_TXT90, M_TXT91,
 	};
 
 #define NUM_MENU_TITLE 3
@@ -196,11 +207,12 @@ menuitem_t Menu_Video[7] = // 8005AA5C
 };
 #endif
 
-#define NUM_MENU_VIDEO 3
+#define NUM_MENU_VIDEO 4
 menuitem_t Menu_Video[NUM_MENU_VIDEO] = {
 	{ 9, 82, 60 }, // Brightness
 	{ 50, 82, 100 }, // Video Filter
-	{ 6, 82, 120 }, // Return
+	{ 88, 82, 120 }, // Quality menu
+	{ 6, 82, 140 }, // Return
 };
 
 #define NUM_MENU_DISPLAY 3
@@ -360,6 +372,8 @@ int M_SENSITIVITY = 0; // 8005A7CC
 boolean FeaturesUnlocked = true; // 8005A7D0
 int MotionBob = 0x100000; // [Immorpher] Motion Bob works in hexadecimal
 int force_filter_flush = 0;
+// 0 low 1 med 2 ultra
+int Quality = 2;
 int VideoFilter = PVR_FILTER_BILINEAR; // [GEC & Immorpher] Set 3 point filtering on or off
 boolean antialiasing = false; // [Immorpher] Anti-Aliasing
 boolean interlacing = false; // [Immorpher] Interlacing
@@ -2024,6 +2038,19 @@ int M_MenuTicker(void)
 					return exit;
 				}
 				break;
+			case 88: // Quality mode
+				if (truebuttons) {
+					S_StartSound(NULL, sfx_switch2);
+					if (Quality == 0) {
+						Quality = 1;
+					} else if (Quality == 1) {
+						Quality = 2;
+					} else if (Quality == 2) {
+						Quality = 0;
+					}
+					return ga_nothing;
+				}
+				break;
 			}
 			exit = ga_nothing;
 		}
@@ -2297,10 +2324,18 @@ void M_VideoDrawer(void) // 80009884
 	item = Menu_Video;
 
 	//    for(i = 0; i < 7; i++)
-	for (i = 0; i < 3; i++) {
+	for (i = 0; i < NUM_MENU_VIDEO; i++) {
 		casepos = item->casepos;
 
-		if (casepos == 50) // [GEC and Immorpher] New video filter
+		if (casepos == 88) // [GEC and Immorpher] New video filter
+		{
+			if (Quality == 0)
+				text = "Low";
+			else if (Quality == 1)
+				text = "Medium";
+			else if (Quality == 2)
+				text = "Ultra";
+		} else if (casepos == 50) // [GEC and Immorpher] New video filter
 		{
 			if (VideoFilter == PVR_FILTER_BILINEAR)
 				text = "On";

--- a/src/m_main.c
+++ b/src/m_main.c
@@ -117,9 +117,9 @@ char *ControlText[] = //8007517C
 #define M_TXT83 "ISANN KEKET" // [Immorpher] Credits
 #define M_TXT84 "NEVANDER" // [Immorpher] Credits
 
-#define M_TXT85 "Absolution"
-#define M_TXT86 "Lost Levels"
-#define M_TXT87 "KneeDeep In The Dead"
+#define M_TXT85 "PLACEHOLDER1"
+#define M_TXT86 "PLACEHOLDER2"
+#define M_TXT87 "PLACEHOLDER3"
 
 #define M_TXT88 "Quality"
 #define M_TXT89 "Low"

--- a/src/r_phase3.c
+++ b/src/r_phase3.c
@@ -6,6 +6,8 @@
 #include <dc/pvr.h>
 #include <math.h>
 
+extern int Quality;
+
 d64Poly_t next_poly;
 
 int context_change;
@@ -290,7 +292,7 @@ void tnl_poly(d64Poly_t *p)
 	//  if any dynamic lights exist
 	//   AND
 	//  we aren't drawing the transparent layer of a liquid floor
-	if ((lightidx + 1) && (!dont_color)) {
+	if (Quality && (lightidx + 1) && (!dont_color)) {
 		(*poly_light_func[lf_idx()])(p);
 	}
 
@@ -1204,7 +1206,8 @@ void R_RenderWall(seg_t *seg, int flags, int texture, int topHeight,
 	dont_color = 0;
 
 	if (bump_txr_ptr[texnum]) {
-		has_bump = 1;
+		if (Quality == 2)
+			has_bump = 1;
 	}
 
 	if (texture != 16) {
@@ -1590,7 +1593,8 @@ void R_RenderSwitch(seg_t *seg, int texture, int topOffset, int color)
 	v2 = seg->linedef->v2;
 
 	if (bump_txr_ptr[texture]) {
-		has_bump = 1;
+		if (Quality == 2)
+			has_bump = 1;
 		defboargb = 0x7f5a00c0;
 	}
 
@@ -1739,7 +1743,8 @@ void R_RenderPlane(leaf_t *leaf, int numverts, int zpos, int texture, int xpos,
 	if (bump_txr_ptr[texnum] && !dont_bump) {
 		float angle = doomangletoQ(viewangle);
 		defboargb = 0x7f5a5a00 | (int)(angle * 255);
-		has_bump = 1;
+		if (Quality == 2)
+			has_bump = 1;
 	}
 
 	in_floor = 1 + ceiling;
@@ -3217,7 +3222,8 @@ void R_RenderPSprites(void)
 			// unmaker
 			lump == 964
 			) {
-				has_bump = 1;
+				if (Quality == 2)
+					has_bump = 1;
 			} else if (
 				lump == 935 ||
 				lump == 939 ||
@@ -3247,6 +3253,7 @@ void R_RenderPSprites(void)
 			float avg_dz = 0;
 			uint32_t wepn_boargb;
 
+			if (Quality) {
 			for (int j = 0; j < lightidx + 1; j++) {
 				float dx = projectile_lights[j].x - px;
 				float dy = projectile_lights[j].y - py;
@@ -3273,10 +3280,12 @@ void R_RenderPSprites(void)
 					}
 				}
 			}
+			}
 			for (int j = 0; j < 4; j++) {
 				quad2[j].argb = quad_color;
 				quad2[j].oargb = quad_light_color;
 			}
+			if (Quality) {
 			if (applied) {
 				if (quad_light_color != 0) {
 					float coord_r =
@@ -3361,6 +3370,7 @@ void R_RenderPSprites(void)
 									((int)K3 << 8) |
 									(int)Q;
 				}
+			}
 			}
 
 			x = (((psp->sx >> 16) - SwapShort(((spriteN64_t *)data)->xoffs)) +


### PR DESCRIPTION
Video menu now has an entry for graphics quality.
Ultra is the default (dynamic lights + normal mapping).
Medium is dynamic lights only.
Low is just normal vanilla Doom 64 renderer with no added effects.

There is a 10+ fps boost between Medium/Ultra and Low quality in maps with very high subsector counts (mostly seen with custom maps, 2000+ polygons in a scene).