### PR TITLE
More performance increases

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Putting them together, to clone the specific KallistiOS repo version you need, b
 
 Now you have a version of KOS identical to what I have validated will work. Follow the build instructions for KOS, including the creation of `environ.sh` and sourcing it.
 
-Before you source it and build KOS, modify `environ.sh` so KOS_CFLAGS has `-O3 -flto=auto` instead of `-O2`.
+Before you source it and build KOS, modify `environ.sh` so `KOS_CFLAGS` has `-O3 -flto=auto` instead of `-O2` (under *Optimization Level*).
+
+Also, in the same file, uncomment the `KOS_CFLAGS` line containing `-ffast-math` (found under *Fast Math Instructions*).
 
 Whenever this pull request finally gets approved and merged, I will update these instructions.
 

--- a/src/c_convert.c
+++ b/src/c_convert.c
@@ -53,8 +53,8 @@ int LightGetHSV(int r, int g, int b)
 		min = b;
 	}
 
-	deltamin = (float)min / 255.0f;
-	deltamax = deltamin - ((float)max / 255.0f);
+	deltamin = (float)min * 0.0039215688593685626983642578125f; //  / 255.0f;
+	deltamax = deltamin - ((float)max * 0.0039215688593685626983642578125f); //  / 255.0f);
 
 	if (deltamin == 0.0f) {
 		j = 0.0f;
@@ -63,9 +63,9 @@ int LightGetHSV(int r, int g, int b)
 	}
 
 	if (j != 0.0f) {
-		xr = (float)r / 255.0f;
-		xg = (float)g / 255.0f;
-		xb = (float)b / 255.0f;
+		xr = (float)r * 0.0039215688593685626983642578125f; // / 255.0f;
+		xg = (float)g * 0.0039215688593685626983642578125f; // / 255.0f;
+		xb = (float)b * 0.0039215688593685626983642578125f; // / 255.0f;
 
 		if (xr != deltamin) {
 			if (xg != deltamin) {
@@ -96,7 +96,8 @@ int LightGetHSV(int r, int g, int b)
 		j = 0.0f;
 	}
 
-	h_ = (int)((x / 360.0f) * 255.0f);
+	h_ = (int)(x * 0.708333313465118408203125f);
+	//(int)((x / 360.0f) * 255.0f);
 
 	s_ = (int)(j * 255.0f);
 
@@ -127,19 +128,19 @@ int LightGetRGB(int h, int s, int v)
 	float xg = 0;
 	float xb = 0;
 
-	j = ((float)h / 255.0f) * 360.0f;
+	j = ((float)h * 1.41176474094390869140625f); // / 255.0f) * 360.0f;
 
 	if (360.0f <= j) {
 		j = j - 360.0f;
 	}
 
-	x = (float)s / 255.0f;
-	i = (float)v / 255.0f;
+	x = (float)s * 0.0039215688593685626983642578125f; // / 255.0f;
+	i = (float)v * 0.0039215688593685626983642578125f; // / 255.0f;
 
 	if (x != 0.0f) {
-		table = (int)(j / 60.0f);
+		table = (int)(j * 0.01666666753590106964111328125f); // / 60.0f);
 		if (table < 6) {
-			t = (float)j / 60.0f;
+			t = j * 0.01666666753590106964111328125f; // / 60.0f;
 			switch (table) {
 			case 0:
 				xr = i;

--- a/src/decodes.c
+++ b/src/decodes.c
@@ -257,6 +257,9 @@ static void InitTables(void) // 8002D468
 =
 ========================
 */
+static short *ct_evenTbl = &DecodeTable[0];
+static short *ct_oddTbl = &DecodeTable[629];
+static short *ct_incrTbl = &DecodeTable[1258];
 
 static void CheckTable(int a0, int a1, int a2) // 8002D624
 {
@@ -264,32 +267,29 @@ static void CheckTable(int a0, int a1, int a2) // 8002D624
 	int idByte1;
 	int idByte2;
 	short *curArray;
-	short *evenTbl;
-	short *oddTbl;
-	short *incrTbl;
 
 	i = 0;
-	evenTbl = &DecodeTable[0];
-	oddTbl = &DecodeTable[629];
-	incrTbl = &DecodeTable[1258];
+//	evenTbl = &DecodeTable[0];
+//	oddTbl = &DecodeTable[629];
+//	incrTbl = &DecodeTable[1258];
 
 	idByte1 = a0;
 
 	do {
-		idByte2 = incrTbl[idByte1];
+		idByte2 = ct_incrTbl[idByte1];
 
 		array01[idByte2] = (array01[a1] + array01[a0]);
 
 		a0 = idByte2;
 
 		if (idByte2 != 1) {
-			idByte1 = incrTbl[idByte2];
-			idByte2 = evenTbl[idByte1];
+			idByte1 = ct_incrTbl[idByte2];
+			idByte2 = ct_evenTbl[idByte1];
 
 			a1 = idByte2;
 
 			if (a0 == idByte2) {
-				a1 = oddTbl[idByte1];
+				a1 = ct_oddTbl[idByte1];
 			}
 		}
 
@@ -403,16 +403,19 @@ static void UpdateTables(int tblpos) // 8002D72C
 ========================
 */
 
+static short *evenTbl = &DecodeTable[0];
+static short *oddTbl = &DecodeTable[629];
+
 static int StartDecodeByte(void) // 8002D904
 {
-	int lookup;
-	short *evenTbl;
-	short *oddTbl;
+//	int lookup;
+//	short *evenTbl;
+//	short *oddTbl;
 
-	lookup = 1;
+	int lookup = 1;
 
-	evenTbl = &DecodeTable[0];
-	oddTbl = &DecodeTable[629];
+//	evenTbl = &DecodeTable[0];
+//	oddTbl = &DecodeTable[629];
 
 	while (lookup < 0x275) {
 		if (ReadBinary() == 0) {

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -46,7 +46,7 @@ typedef struct {
 #define STORAGE_PREFIX "/cd"
 #define MAX_CACHED_SPRITES 256
 
-#define TR_VERTBUF_SIZE (1152 * 1024)
+#define TR_VERTBUF_SIZE (1536 * 1024)
 extern uint8_t __attribute__((aligned(32))) tr_buf[TR_VERTBUF_SIZE];
 
 extern int context_change;
@@ -108,6 +108,8 @@ typedef struct {
 	float w;
 	float r,g,b;
 	int lit;
+	uint32_t pad1;
+	uint32_t pad2;
 } d64ListVert_t;
 
 typedef struct {
@@ -785,29 +787,9 @@ short LittleShort(short dat);
 long LongSwap(long dat);
 
 fixed_t FixedMul(fixed_t a, fixed_t b);
-//fixed_t FixedDiv(fixed_t a, fixed_t b);
+fixed_t FixedDiv(fixed_t a, fixed_t b);
 fixed_t FixedDiv2(fixed_t a, fixed_t b);
-#define FixedDiv FixedDiv2
-
-//extern fixed_t FixedMul2 (fixed_t a, fixed_t b);// ASM MIPS CODE
-//extern fixed_t FixedDiv3 (fixed_t a, fixed_t b);// ASM MIPS CODE
-#if 0
-#ifdef __BIG_ENDIAN__
-#define __BIG_ENDIAN__
-#endif
-#endif
-
-#ifdef __BIG_ENDIAN__
-
-#define LONGSWAP(x) (x)
-#define LITTLESHORT(x) (x)
-
-#else
-
-#define LONGSWAP(x) LongSwap(x)
-#define LITTLESHORT(x) LittleShort(x)
-
-#endif // __BIG_ENDIAN__
+fixed_t FixedDivFloat(fixed_t a, fixed_t b);
 
 /*----------- */
 /*MEMORY ZONE */

--- a/src/f_main.c
+++ b/src/f_main.c
@@ -381,8 +381,11 @@ static int fadeinout; // 80063224
 =================
 */
 
+extern void P_FlushAllCached(void);
+
 void F_Start(void) // 8000313C
 {
+	P_FlushAllCached();
 	DrawerStatus = 3;
 	finalestage = F_STAGE_FADEIN_BACKGROUD;
 	fadeinout = 0;

--- a/src/in_main.c
+++ b/src/in_main.c
@@ -84,9 +84,13 @@ int start_time; // 80063390
 int end_time; // 80063394
 extern int extra_episodes;
 
+extern void P_FlushAllCached(void);
+
 void IN_Start(void) // 80004AF0
 {
 	int time;
+
+	P_FlushAllCached();
 
 	killvalue = itemvalue = secretvalue = -1;
 

--- a/src/m_fixed.c
+++ b/src/m_fixed.c
@@ -19,7 +19,6 @@ fixed_t D_abs(fixed_t x)
 =
 ===============
 */
-#if 0
 fixed_t FixedDiv(fixed_t a, fixed_t b)
 {
     fixed_t     aa, bb;
@@ -52,7 +51,6 @@ fixed_t FixedDiv(fixed_t a, fixed_t b)
 
     return c;
 }
-#endif
 
 /*
 ===============
@@ -66,6 +64,14 @@ fixed_t FixedDiv2(register fixed_t a, register fixed_t b)
 	s64 result = ((s64)a << 16) / (s64)b;
 
 	return (fixed_t)result;
+}
+
+fixed_t FixedDivFloat(register fixed_t a, register fixed_t b)
+{
+	float af = (float)a;
+	float bf = (float)b;
+	float cf = af/bf;
+	return (fixed_t)(cf * 65536.0f);
 }
 
 /*

--- a/src/m_main.c
+++ b/src/m_main.c
@@ -2188,7 +2188,7 @@ void M_FeaturesDrawer(void) // 800091C0
 
 	for (i = 0; i < itemlines; i++) {
 		if ((item->casepos == 23) &&
-		    ((m_actualmap >= 25) && (m_actualmap <= 27))) {
+		    ((((m_actualmap >= 25) && (m_actualmap <= 27))) || (m_actualmap == 40))) {
 			/* Show "WARP TO FUN" text */
 			ST_Message(item->x, item->y, MenuText[40],
 				   text_alpha | 0xffffff00,1);
@@ -2200,7 +2200,7 @@ void M_FeaturesDrawer(void) // 800091C0
 				   text_alpha | 0xffffff00,1);
 		} else if ((item->casepos == 23) &&
 			   (m_actualmap >
-			    28)) // [Immorpher] Show "WARP TO SECRET" text
+			    28) && (m_actualmap < 34)) // [Immorpher] Show "WARP TO SECRET" text
 		{
 			ST_Message(item->x, item->y, MenuText[66],
 				   text_alpha | 0xffffff00,1);

--- a/src/p_spec.c
+++ b/src/p_spec.c
@@ -87,10 +87,6 @@ extern uint8_t *pt;
 static uint16_t tmp_argb1555_txr[64 * 64];
 static uint16_t tmp_pal[16];
 
-// set after first time P_Init is called
-// don't do PVR texture cache cleanup when 0
-static int P_Init_calls = 0;
-
 // twiddling stuff copied from whatever filed copied it from kmgenc.c
 #define TWIDTAB(x)                                                    \
 	((x & 1) | ((x & 2) << 1) | ((x & 4) << 2) | ((x & 8) << 3) | \
@@ -101,20 +97,110 @@ static int P_Init_calls = 0;
 
 #define _PAD8(x) x += (8 - ((uint)x & 7)) & 7
 
-#if 0
-void texture_tests(void)
-{
-	for(int i=0;i<503;i++) {
-		void *data = W_CacheLumpNum(i + firsttex, PU_CACHE, dec_d64);
-		short numpalfortex = SwapShort(((textureN64_t *)data)->numpal);
-		if (numpalfortex > 1)
-			dbgio_printf("Texture %s has %d palettes\n", W_GetNameForNum(firsttex + i), numpalfortex);
-		Z_Free(data);
-	}
-}
-#endif
+extern pvr_ptr_t pvr_spritecache[MAX_CACHED_SPRITES];
+extern pvr_poly_hdr_t hdr_spritecache[MAX_CACHED_SPRITES];
+extern pvr_poly_cxt_t cxt_spritecache[MAX_CACHED_SPRITES];
 
-void *P_CachePvrTexture(int i, int tag)
+extern int lump_frame[575 + 310];
+extern int used_lumps[575 + 310];
+extern int used_lump_idx;
+extern int delidx;
+extern int total_cached_vram;
+
+extern int last_flush_frame;
+
+extern int force_filter_flush;
+extern int vram_low;
+
+// flush only PVR monster sprites
+void  __attribute__((noinline)) P_FlushSprites(void)
+{
+	force_filter_flush = 0;
+	vram_low = 0;
+#define ALL_SPRITES_INDEX (575 + 310)
+	for (unsigned i = 0; i < ALL_SPRITES_INDEX; i++) {
+		if (used_lumps[i] != -1) {
+//			dbgio_printf("P_FlushSprites(%u) == %d\n", i, used_lumps[i]);
+			if (pvr_spritecache[used_lumps[i]]) {
+//				dbgio_printf("pvr_spritecache[%d] existed, freeing\n", used_lumps[i]);
+				pvr_mem_free(pvr_spritecache[used_lumps[i]]);
+				pvr_spritecache[used_lumps[i]] = NULL;
+			}
+		}
+	}
+
+	memset(used_lumps, 0xff, sizeof(int) * ALL_SPRITES_INDEX);
+	memset(lump_frame, 0xff, sizeof(int) * ALL_SPRITES_INDEX);
+
+	used_lump_idx = 0;
+	delidx = 0;
+
+	last_flush_frame = NextFrameIdx;
+}
+
+// flush PVR monster sprites and PVR textures
+void  __attribute__((noinline)) P_FlushAllCached(void) {
+	unsigned i, j;
+	P_FlushSprites();
+	// clear previously cached pvr textures
+	for (i = 0; i < numtextures; i++) {
+		// for all combo of texture + palette
+		for (j = 0; j < num_pal[i]; j++) {
+			// a non-zero value means allocated texture
+			if (pvr_texture_ptrs[i][j]) {
+				pvr_mem_free(pvr_texture_ptrs[i][j]);
+			}
+		}
+
+		if (bump_txr_ptr[i]) {
+			pvr_mem_free(bump_txr_ptr[i]);
+		}
+
+		// free the array of texture pointers
+		if (NULL != pvr_texture_ptrs[i]) {
+			free(pvr_texture_ptrs[i]);
+			pvr_texture_ptrs[i] = NULL;
+		}
+		// free the array of contexts
+		if (NULL != txr_cxt_bump[i]) {
+			free(txr_cxt_bump[i]);
+			txr_cxt_bump[i] = NULL;
+		}
+
+		if (NULL != txr_cxt_nobump[i]) {
+			free(txr_cxt_nobump[i]);
+			txr_cxt_nobump[i] = NULL;
+		}
+
+		if (NULL != bump_cxt[i]) {
+			free(bump_cxt[i]);
+			bump_cxt[i] = NULL;
+		}
+
+		// free the array of contexts
+		if (NULL != txr_hdr_bump[i]) {
+			free(txr_hdr_bump[i]);
+			txr_hdr_bump[i] = NULL;
+		}
+
+		if (NULL != txr_hdr_nobump[i]) {
+			free(txr_hdr_nobump[i]);
+			txr_hdr_nobump[i] = NULL;
+		}
+
+		if (NULL != bump_hdrs[i]) {
+			free(bump_hdrs[i]);
+			bump_hdrs[i] = NULL;
+		}
+
+		// set to 0 so the following calls will start from scratch
+		num_pal[i] = 0;
+	}
+
+	memset(bump_txr_ptr, 0, sizeof(pvr_ptr_t) * numtextures);
+}
+
+void __attribute__((noinline)) *P_CachePvrTexture(int i, int tag)
 {
 	unsigned j, k;
 
@@ -150,6 +236,7 @@ void *P_CachePvrTexture(int i, int tag)
 		I_Error("P_CachePvrTexture: could not allocate\n"
 			"tex_txr_ptr array for %d\n", i);
 	}
+
 	// for each palette, allocate a pvr_poly_cxt_t
 	// we have a context for each palette
 	// we first create them for when the texture is used with bump-mapping
@@ -182,22 +269,11 @@ void *P_CachePvrTexture(int i, int tag)
 			"txr_hdr_nobump array for %d\n", i);
 	}
 
-#if 0	
-	// and then we create them for when the texture is used without bump-mapping
-	// and needs to be transparent
-	txr_cxt_tr_nobump[i] =
-		(pvr_poly_cxt_t *)malloc(numpalfortex * sizeof(pvr_poly_cxt_t));
-	if (NULL == txr_cxt_tr_nobump[i]) {
-		I_Error("P_CachePvrTexture: could not allocate\n"
-			"txr_cxt_tr_forbump array for %d\n", i);
-	}
-#endif
-
 	// textureN64_t, unlike other Doom 64 graphics, are always pow2, thankfully
-	int width = (1 << SwapShort(((textureN64_t *)data)->wshift));
-	int height = (1 << SwapShort(((textureN64_t *)data)->hshift));
+	unsigned width = (1 << SwapShort(((textureN64_t *)data)->wshift));
+	unsigned height = (1 << SwapShort(((textureN64_t *)data)->hshift));
 	// size -- 4bpp
-	int size = (width * height) / 2;
+	unsigned size = (width * height) >> 1;
 	// padded to a multiple of 8
 	//_PAD8(size);
 
@@ -218,7 +294,12 @@ void *P_CachePvrTexture(int i, int tag)
 			// allocate PVR texture memory for bumpmap
 			bump_txr_ptr[i] = pvr_mem_malloc(bumpsize);
 			if (!bump_txr_ptr[i]) {
-				I_Error("PVR OOM for normal map %d\n", i);
+//				dbgio_printf("P_CachePvrTexture code saw low vram normal map\n");
+				P_FlushSprites();
+				pvr_texture_ptrs[i][k] = pvr_mem_malloc(width * height * sizeof(uint16_t));
+				if (!pvr_texture_ptrs[i][k]) {
+					I_Error("PVR OOM for normal map %d after sprite flush", i);
+				}
 			}
 			bump_cxt[i] =
 				(pvr_poly_cxt_t *)malloc(1 * sizeof(pvr_poly_cxt_t));
@@ -259,16 +340,18 @@ void *P_CachePvrTexture(int i, int tag)
 
 	// Flip nibbles per byte
 	uint8_t *src8 = (uint8_t *)src;
-	int mask = width / 8;
+	//int mask = width / 8;
+	unsigned mask = width >> 3;
 	for (k = 0; k < size; k++) {
 		byte tmp = src8[k];
 		src8[k] = (tmp >> 4);
 		src8[k] |= ((tmp & 0xf) << 4);
 	}
-
+	size >>= 2;
 	// Flip each sets of dwords based on texture width
 	int *src32 = (int *)(src);
-	for (k = 0; k < size / 4; k += 2) {
+	//for (k = 0; k < size / 4; k += 2) {
+	for (k = 0; k < size; k += 2) {
 		int x1;
 		int x2;
 		if (k & mask) {
@@ -298,7 +381,12 @@ void *P_CachePvrTexture(int i, int tag)
 		// ARGB1555 texture allocation in PVR memory
 		pvr_texture_ptrs[i][k] = pvr_mem_malloc(width * height * sizeof(uint16_t));
 		if (!pvr_texture_ptrs[i][k]) {
-			I_Error("PVR OOM for texture [%d][%d]\n", i, k);
+//			dbgio_printf("P_CachePvrTexture code saw low vram texture\n");
+			P_FlushSprites();
+			pvr_texture_ptrs[i][k] = pvr_mem_malloc(width * height * sizeof(uint16_t));
+			if (!pvr_texture_ptrs[i][k]) {
+				I_Error("PVR OOM for texture [%d][%d] after sprite flush", i, k);
+			}
 		}
 
 		// pointer to N64 format 16-color palette for this texture/palnum combination
@@ -383,27 +471,7 @@ void *P_CachePvrTexture(int i, int tag)
 		txr_cxt_nobump[i][k].gen.fog_type2 = PVR_FOG_TABLE;
 
 		pvr_poly_compile(&txr_hdr_nobump[i][k], &txr_cxt_nobump[i][k]);
-//		free(txr_cxt_nobump[i]);
-//		txr_cxt_nobump[i] = NULL;
 
-		// ====================================================================
-#if 0
-		// third set of poly contexts with blend src/dst settings
-		//   needed for transparent floors
-		// used without bump-mapping
-		pvr_poly_cxt_txr(&txr_cxt_tr_nobump[i][k], PVR_LIST_TR_POLY,
-				 PVR_TXRFMT_ARGB1555 | PVR_TXRFMT_TWIDDLED,
-				 width, height, pvr_texture_ptrs[i][k],
-				 PVR_FILTER_BILINEAR);
-
-		// specular field holds lighting color
-		txr_cxt_tr_nobump[i][k].gen.specular = PVR_SPECULAR_ENABLE;
-		// Doom 64 fog
-		txr_cxt_tr_nobump[i][k].gen.fog_type = PVR_FOG_TABLE;
-		txr_cxt_tr_nobump[i][k].gen.fog_type2 = PVR_FOG_TABLE;
-		txr_cxt_tr_nobump[i][k].blend.src = PVR_BLEND_ONE;
-		txr_cxt_tr_nobump[i][k].blend.dst = PVR_BLEND_DESTALPHA;
-#endif
 		// ====================================================================
 	}
 
@@ -425,92 +493,11 @@ extern int delidx;
 
 void P_Init(void)
 {
-	int i, j;
+	unsigned i;
 	sector_t *sector;
 	side_t *side;
 
-	// clean up any caching of sprites
-
-	if (donebefore) {
-		for (int i = 0; i < (575 + 310); i++) {
-			if (used_lumps[i] != -1) {
-				pvr_mem_free(pvr_spritecache[used_lumps[i]]);
-			}
-		}
-	}
-	memset(used_lumps, 0xff, sizeof(int) * (575 + 310));
-	memset(lump_frame, 0xff, sizeof(int) * (575 + 310));
-	used_lump_idx = 0;
-	delidx = 0;
-	donebefore = 1;
-
-	// clean up any caching of textures
-
-	if (P_Init_calls) {
-		// clear previously cached pvr textures
-		for (i = 0; i < numtextures; i++) {
-			// for all combo of texture + palette
-			for (j = 0; j < num_pal[i]; j++) {
-				// a non-zero value means allocated texture
-				if (pvr_texture_ptrs[i][j]) {
-					pvr_mem_free(pvr_texture_ptrs[i][j]);
-				}
-			}
-			if (bump_txr_ptr[i]) {
-				pvr_mem_free(bump_txr_ptr[i]);
-			}
-
-			// free the array of texture pointers
-			if (NULL != pvr_texture_ptrs[i]) {
-				free(pvr_texture_ptrs[i]);
-				pvr_texture_ptrs[i] = NULL;
-			}
-			// free the array of contexts
-			if (NULL != txr_cxt_bump[i]) {
-				free(txr_cxt_bump[i]);
-				txr_cxt_bump[i] = NULL;
-			}
-
-			if (NULL != txr_cxt_nobump[i]) {
-				free(txr_cxt_nobump[i]);
-				txr_cxt_nobump[i] = NULL;
-			}
-
-			if (NULL != bump_cxt[i]) {
-				free(bump_cxt[i]);
-				bump_cxt[i] = NULL;
-			}
-
-			// free the array of contexts
-			if (NULL != txr_hdr_bump[i]) {
-				free(txr_hdr_bump[i]);
-				txr_hdr_bump[i] = NULL;
-			}
-
-			if (NULL != txr_hdr_nobump[i]) {
-				free(txr_hdr_nobump[i]);
-				txr_hdr_nobump[i] = NULL;
-			}
-
-			if (NULL != bump_hdrs[i]) {
-				free(bump_hdrs[i]);
-				bump_hdrs[i] = NULL;
-			}
-
-
-#if 0
-			if (NULL != txr_cxt_tr_nobump[i]) {
-				free(txr_cxt_tr_nobump[i]);
-				txr_cxt_tr_nobump[i] = NULL;
-			}
-#endif
-			// set to 0 so the following calls will start from scratch
-			num_pal[i] = 0;
-		}
-
-		memset(bump_txr_ptr, 0, sizeof(pvr_ptr_t) * numtextures);
-//		memset(bump_cxt, 0, sizeof(pvr_poly_cxt_t) * numtextures);
-	}
+	P_FlushAllCached();
 
 	side = sides;
 	for (i = 0; i < numsides; i++, side++) {
@@ -531,8 +518,6 @@ void P_Init(void)
 			P_CachePvrTexture(sector->floorpic + 1, PU_LEVEL);
 		}
 	}
-
-	P_Init_calls++;
 }
 
 /*
@@ -1601,1554 +1586,3 @@ boolean P_UseSpecialLine(line_t *line, mobj_t *thing)
 
 	return true;
 }
-
-
-
-#if 0
-/* P_Spec.c */
-#include "doomdef.h"
-#include "r_local.h"
-#include "p_local.h"
-#include "st_main.h"
-
-extern mapthing_t *spawnlist;
-extern int spawncount;
-
-line_t **linespeciallist;
-int numlinespecials;
-
-sector_t **sectorspeciallist;
-int numsectorspecials;
-
-animdef_t animdefs[MAXANIMS] =
-	{ { 15, "SMONAA", 4, 7, false, false },
-	  { 0, "SMONBA", 4, 1, false, false },
-	  { 0, "SMONCA", 4, 7, false, false },
-	  { 90, "CFACEA", 3, 3, true, false },
-	  { 0, "SMONDA", 4, 3, false, false },
-	  { 10, "SMONEA", 4, 7, false, false },
-	  { 0, "SPORTA", 9, 3, false, true },
-	  { 10, "SMONF", 5, 1, true, true },
-	  { 10, "STRAKR", 5, 1, true, true },
-	  { 10, "STRAKB", 5, 1, true, true },
-	  { 10, "STRAKY", 5, 1, true, true },
-	  { 50, "C307B", 5, 1, true, true },
-	  { 0, "CTEL", 8, 3, false, true },
-	  { 0, "CASFL98", 5, 7, true, true },
-	  { 0, "HTELA", 4, 1, true, false } };
-
-/*----------
-/ anims[8] -> anims[MAXANIMS = 15]
-/ For some reason Doom 64 is 8,
-/ I will leave it at 15 to avoid problems loading data into this pointer.
-/---------*/
-anim_t anims[MAXANIMS], *lastanim;
-
-card_t MapBlueKeyType;
-card_t MapRedKeyType;
-card_t MapYellowKeyType;
-
-void P_AddSectorSpecial(sector_t *sec);
-
-/*
-=================
-=
-= P_Init
-=
-=================
-*/
-
-// PVR texture memory pointers for texture[texnum][palnum]
-extern pvr_ptr_t **pvr_texture_ptrs;
-// PVR poly context for each texture[texnum][palnum] when bump-mapped
-// for PT list
-extern pvr_poly_cxt_t **txr_cxt_bump;
-
-// PVR poly context for each texture[texnum][palnum] when *NOT* bump-mapped
-// for PT list
-//  textured floors in automap
-//  alpha == 255
-extern pvr_poly_cxt_t **txr_cxt_nobump;
-
-// PVR poly context for each texture[texnum][palnum] when *NOT* bump-mapped
-// for TR list
-//  alpha != 255
-extern pvr_poly_cxt_t **txr_cxt_tr_nobump;
-
-// PVR texture memory pointer for bumpmap_texture[texnum]
-extern pvr_ptr_t *bump_txr_ptr;
-// PVR poly context for each bumpmap_texture[texnum][palnum]
-// for OP list
-extern pvr_poly_cxt_t **bump_cxt;
-
-// number of palettes for texture[texnum]
-extern uint8_t *num_pal;
-
-// texture with alpha holes (could use PT list)
-extern uint8_t *pt;
-
-// make sure we always have enough space to convert textures to ARGB1555
-static uint16_t tmp_argb1555_txr[64 * 64];
-static uint16_t tmp_pal[16];
-
-// set after first time P_Init is called
-// don't do PVR texture cache cleanup when 0
-static int P_Init_calls = 0;
-
-// twiddling stuff copied from whatever filed copied it from kmgenc.c
-#define TWIDTAB(x)                                                    \
-	((x & 1) | ((x & 2) << 1) | ((x & 4) << 2) | ((x & 8) << 3) | \
-	 ((x & 16) << 4) | ((x & 32) << 5) | ((x & 64) << 6) |        \
-	 ((x & 128) << 7) | ((x & 256) << 8) | ((x & 512) << 9))
-#define TWIDOUT(x, y) (TWIDTAB((y)) | (TWIDTAB((x)) << 1))
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-
-#define _PAD8(x) x += (8 - ((uint)x & 7)) & 7
-
-#if 0
-void texture_tests(void)
-{
-	for(int i=0;i<503;i++) {
-		void *data = W_CacheLumpNum(i + firsttex, PU_CACHE, dec_d64);
-		short numpalfortex = SwapShort(((textureN64_t *)data)->numpal);
-		if (numpalfortex > 1)
-			dbgio_printf("Texture %s has %d palettes\n", W_GetNameForNum(firsttex + i), numpalfortex);
-		Z_Free(data);
-	}
-}
-#endif
-
-void *P_CachePvrTexture(int i, int tag)
-{
-	unsigned j, k;
-
-	// get texture from WAD, decompress, cache it
-	void *data = W_CacheLumpNum(i + firsttex, tag, dec_d64);
-
-	// if P_CachePvrTexture has been called for this texture before
-	// num_pal[i] will have been set to a non-zero value
-	// texture is in PVR memory and wad cache, return early
-	if (num_pal[i]) {
-		return data;
-	}
-
-	// Doom 64 Tech Bible says this needs special handling
-	// no alpha for color 0
-	int slime = 0;
-	int slimea_num = W_CheckNumForName("SLIMEA", 0x7fffffff, 0xffffffff);
-	int slimeb_num = W_CheckNumForName("SLIMEB", 0x7fffffff, 0xffffffff);
-	if (((slimea_num - firsttex) == i) || ((slimeb_num - firsttex) == i)) {
-		slime = 1;
-	}
-
-	// most textures have one palette
-	// 9 textures have more than one (5, 8 or 9 palettes)
-	short numpalfortex = SwapShort(((textureN64_t *)data)->numpal);
-
-	// record how many palettes texture i has
-	num_pal[i] = numpalfortex;
-	// for each palette, allocate a pointer to a pvr_ptr_t
-	// we are going to create an argb1555 texture for each palette
-	pvr_texture_ptrs[i] = (pvr_ptr_t *)malloc(numpalfortex * sizeof(pvr_ptr_t));
-	if (NULL == pvr_texture_ptrs[i]) {
-		I_Error("P_CachePvrTexture: could not allocate\n"
-			"tex_txr_ptr array for %d\n", i);
-	}
-	// for each palette, allocate a pvr_poly_cxt_t
-	// we have a context for each palette
-	// we first create them for when the texture is used with bump-mapping
-	// requires non-default blend settings
-	txr_cxt_bump[i] =
-		(pvr_poly_cxt_t *)malloc(numpalfortex * sizeof(pvr_poly_cxt_t));
-	if (NULL == txr_cxt_bump[i]) {
-		I_Error("P_CachePvrTexture: could not allocate\n"
-			"txr_cxt_bump array for %d\n", i);
-	}
-
-	// we then create them for when the texture is used without bump-mapping
-	// these use default blend settings
-	txr_cxt_nobump[i] =
-		(pvr_poly_cxt_t *)malloc(numpalfortex * sizeof(pvr_poly_cxt_t));
-	if (NULL == txr_cxt_nobump[i]) {
-		I_Error("P_CachePvrTexture: could not allocate\n"
-			"txr_cxt_nobump array for %d\n", i);
-	}
-
-#if 0	
-	// and then we create them for when the texture is used without bump-mapping
-	// and needs to be transparent
-	txr_cxt_tr_nobump[i] =
-		(pvr_poly_cxt_t *)malloc(numpalfortex * sizeof(pvr_poly_cxt_t));
-	if (NULL == txr_cxt_tr_nobump[i]) {
-		I_Error("P_CachePvrTexture: could not allocate\n"
-			"txr_cxt_tr_forbump array for %d\n", i);
-	}
-#endif
-
-	// textureN64_t, unlike other Doom 64 graphics, are always pow2, thankfully
-	int width = (1 << SwapShort(((textureN64_t *)data)->wshift));
-	int height = (1 << SwapShort(((textureN64_t *)data)->hshift));
-	// size -- 4bpp
-	int size = (width * height) / 2;
-	// padded to a multiple of 8
-	//_PAD8(size);
-
-	// pixels start here
-	uintptr_t src = (uintptr_t)data + sizeof(textureN64_t);
-
-	// get the name of the given texture index
-	char *bname = W_GetNameForNum(i + firsttex);
-	// skip these "YOU SUCK AT MAKING MAPS" texture
-	// this also skips 'BLOOD*' but we don't have those currently
-	if (bname[0] != '?' && (bname[0] != 'B')) {
-		// find bumpmap WAD lump number for texture name
-		int bump_lumpnum = W_Bump_GetNumForName(bname);
-		// not -1 means a bumpmap exists for this texture
-		if (bump_lumpnum != -1) {
-			// 16bpp (S,R) format
-			int bumpsize = (width * height * 2);
-			// allocate PVR texture memory for bumpmap
-			bump_txr_ptr[i] = pvr_mem_malloc(bumpsize);
-			if (!bump_txr_ptr[i]) {
-				I_Error("PVR OOM for normal map %d\n", i);
-			}
-			bump_cxt[i] =
-				(pvr_poly_cxt_t *)malloc(1 * sizeof(pvr_poly_cxt_t));
-			if (NULL == bump_cxt[i]) {
-				I_Error("P_CachePvrTexture: could not allocate\n"
-					"bump_cxt array for %d\n", i);
-			}
-			// read bumpmap from WAD directly into PVR memory
-			// there is decompression and twiddling happening under the hood
-			W_Bump_ReadLump(bump_lumpnum, (uint8_t *)bump_txr_ptr[i], width, height);
-
-			// PVR context for rendering a bump poly with this texture
-			pvr_poly_cxt_txr(&bump_cxt[i][0], PVR_LIST_OP_POLY,
-					 PVR_TXRFMT_BUMP | PVR_TXRFMT_TWIDDLED,
-					 width, height, bump_txr_ptr[i],
-					 PVR_FILTER_BILINEAR);
-
-			// settings required for bump texturing
-			bump_cxt[i][0].gen.specular = PVR_SPECULAR_ENABLE;
-			bump_cxt[i][0].txr.env = PVR_TXRENV_DECAL;
-			//bump_cxt[i].blend.src = PVR_BLEND_ONE;
-			//bump_cxt[i].blend.dst = PVR_BLEND_ZERO;
-		}
-	}
-
-	// process texture from n64 format with swapped rows etc
-
-	// Flip nibbles per byte
-	uint8_t *src8 = (uint8_t *)src;
-	int mask = width / 8;
-	for (k = 0; k < size; k++) {
-		byte tmp = src8[k];
-		src8[k] = (tmp >> 4);
-		src8[k] |= ((tmp & 0xf) << 4);
-	}
-
-	// Flip each sets of dwords based on texture width
-	int *src32 = (int *)(src);
-	for (k = 0; k < size / 4; k += 2) {
-		int x1;
-		int x2;
-		if (k & mask) {
-			x1 = *(int *)(src32 + k);
-			x2 = *(int *)(src32 + k + 1);
-			*(int *)(src32 + k) = x2;
-			*(int *)(src32 + k + 1) = x1;
-		}
-	}
-
-	// pixels are in correct order at this point but still 4bpp
-
-	// most textures have a single palette,
-	// 494 out of 503 total
-	//
-	// the list of those that do not:
-	// C307B has 5 palettes
-	// SMONF has 5 palettes
-	// SPACEAZ has 5 palettes
-	// STRAKB has 5 palettes
-	// STRAKR has 5 palettes
-	// STRAKY has 5 palettes
-	// CASFL98 has 5 palettes
-	// CTEL has 8 palettes
-	// SPORTA has 9 palettes
-	for (k = 0; k < numpalfortex; k++) {
-		// ARGB1555 texture allocation in PVR memory
-		pvr_texture_ptrs[i][k] = pvr_mem_malloc(width * height * sizeof(uint16_t));
-		if (!pvr_texture_ptrs[i][k]) {
-			I_Error("PVR OOM for texture [%d][%d]\n", i, k);
-		}
-
-		// pointer to N64 format 16-color palette for this texture/palnum combination
-		// skip 4 textureN64_t fields, skip (w*h/2) bytes of pixels, skip (k*32) bytes
-		// to get to palette k
-		short *p = (short *)(src + (uintptr_t)((width * height) >> 1) +
-							(uintptr_t)(k << 5));
-
-		// these are all 16 color palettes (4bpp)
-		for (j = 0; j < 16; j++) {
-			short val = SwapShort(*p++);
-			u8 r = (val & 0xF800) >> 8;
-			u8 g = (val & 0x07C0) >> 3;
-			u8 b = (val & 0x003E) << 2;
-
-			// Doom 64 EX Tech Bible says this needs special handling
-			// color 0 transparent only if not slime
-			if (slime == 0 && j == 0 && r == 0 && g == 0 && b == 0) {
-				// leaving this here in case we ever try to use PT polys again
-				pt[i] = 1;
-
-				tmp_pal[j] = get_color_argb1555(0, 0, 0, 0);
-			} else {
-				tmp_pal[j] = get_color_argb1555(r, g, b, 1);
-			}
-		}
-
-		// 16-bit conversion of texture data in memory
-		for (j = 0; j < (width * height); j += 2) {
-			uint8_t pair_pix4bpp = src8[j >> 1];
-			tmp_argb1555_txr[j    ] = tmp_pal[(pair_pix4bpp     ) & 0xf];
-			tmp_argb1555_txr[j + 1] = tmp_pal[(pair_pix4bpp >> 4) & 0xf];
-		}
-
-		// twiddle directly into PVR texture memory
-		int twmin = MIN(width, height);
-		int twmask = twmin - 1;
-		uint16_t *twidbuffer = (uint16_t *)pvr_texture_ptrs[i][k];
-		for (unsigned y = 0; y < height; y++) {
-			unsigned yout = y;
-			for (unsigned x = 0; x < width; x++) {
-				twidbuffer[TWIDOUT(x & twmask, yout & twmask) +
-					   (x / twmin + yout / twmin) * twmin *
-						   twmin] =
-					tmp_argb1555_txr[(y * width) + x];
-			}
-		}
-
-		// ====================================================================
-
-		// set of poly contexts with blend src/dst settings for bump-mapping
-		pvr_poly_cxt_txr(&txr_cxt_bump[i][k], PVR_LIST_TR_POLY,
-				 PVR_TXRFMT_ARGB1555 | PVR_TXRFMT_TWIDDLED,
-				 width, height, pvr_texture_ptrs[i][k],
-				 PVR_FILTER_BILINEAR);
-
-		// specular field holds lighting color
-		txr_cxt_bump[i][k].gen.specular = PVR_SPECULAR_ENABLE;
-		// Doom 64 fog
-		txr_cxt_bump[i][k].gen.fog_type = PVR_FOG_TABLE;
-		txr_cxt_bump[i][k].gen.fog_type2 = PVR_FOG_TABLE;
-		txr_cxt_bump[i][k].blend.src = PVR_BLEND_DESTCOLOR;
-		txr_cxt_bump[i][k].blend.dst = PVR_BLEND_ZERO;
-
-		// ====================================================================
-
-		// second set of poly contexts with default blend src/dst settings
-		// used without bump-mapping
-		pvr_poly_cxt_txr(&txr_cxt_nobump[i][k], PVR_LIST_TR_POLY,
-				 PVR_TXRFMT_ARGB1555 | PVR_TXRFMT_TWIDDLED,
-				 width, height, pvr_texture_ptrs[i][k],
-				 PVR_FILTER_BILINEAR);
-
-		// specular field holds lighting color
-		txr_cxt_nobump[i][k].gen.specular = PVR_SPECULAR_ENABLE;
-		// Doom 64 fog
-		txr_cxt_nobump[i][k].gen.fog_type = PVR_FOG_TABLE;
-		txr_cxt_nobump[i][k].gen.fog_type2 = PVR_FOG_TABLE;
-
-		// ====================================================================
-#if 0
-		// third set of poly contexts with blend src/dst settings
-		//   needed for transparent floors
-		// used without bump-mapping
-		pvr_poly_cxt_txr(&txr_cxt_tr_nobump[i][k], PVR_LIST_TR_POLY,
-				 PVR_TXRFMT_ARGB1555 | PVR_TXRFMT_TWIDDLED,
-				 width, height, pvr_texture_ptrs[i][k],
-				 PVR_FILTER_BILINEAR);
-
-		// specular field holds lighting color
-		txr_cxt_tr_nobump[i][k].gen.specular = PVR_SPECULAR_ENABLE;
-		// Doom 64 fog
-		txr_cxt_tr_nobump[i][k].gen.fog_type = PVR_FOG_TABLE;
-		txr_cxt_tr_nobump[i][k].gen.fog_type2 = PVR_FOG_TABLE;
-		txr_cxt_tr_nobump[i][k].blend.src = PVR_BLEND_ONE;
-		txr_cxt_tr_nobump[i][k].blend.dst = PVR_BLEND_DESTALPHA;
-#endif
-		// ====================================================================
-	}
-	return data;
-}
-
-int donebefore = 0;
-
-extern pvr_ptr_t pvr_spritecache[MAX_CACHED_SPRITES];
-extern int lump_frame[(575 + 310)];
-extern int used_lumps[(575 + 310)];
-extern int used_lump_idx;
-extern int delidx;
-
-void P_Init(void)
-{
-	int i, j;
-	sector_t *sector;
-	side_t *side;
-
-	// clean up any caching of sprites
-
-	if (donebefore) {
-		for (int i = 0; i < (575 + 310); i++) {
-			if (used_lumps[i] != -1) {
-				pvr_mem_free(pvr_spritecache[used_lumps[i]]);
-			}
-		}
-	}
-	memset(used_lumps, 0xff, sizeof(int) * (575 + 310));
-	memset(lump_frame, 0xff, sizeof(int) * (575 + 310));
-	used_lump_idx = 0;
-	delidx = 0;
-	donebefore = 1;
-
-	// clean up any caching of textures
-
-	if (P_Init_calls) {
-		// clear previously cached pvr textures
-		for (i = 0; i < numtextures; i++) {
-			// for all combo of texture + palette
-			for (j = 0; j < num_pal[i]; j++) {
-				// a non-zero value means allocated texture
-				if (pvr_texture_ptrs[i][j]) {
-					pvr_mem_free(pvr_texture_ptrs[i][j]);
-				}
-			}
-			if (bump_txr_ptr[i]) {
-				pvr_mem_free(bump_txr_ptr[i]);
-			}
-
-			// free the array of texture pointers
-			if (NULL != pvr_texture_ptrs[i]) {
-				free(pvr_texture_ptrs[i]);
-				pvr_texture_ptrs[i] = NULL;
-			}
-			// free the array of contexts
-			if (NULL != txr_cxt_bump[i]) {
-				free(txr_cxt_bump[i]);
-				txr_cxt_bump[i] = NULL;
-			}
-
-			if (NULL != txr_cxt_nobump[i]) {
-				free(txr_cxt_nobump[i]);
-				txr_cxt_nobump[i] = NULL;
-			}
-
-			if (NULL != bump_cxt[i]) {
-				free(bump_cxt[i]);
-				bump_cxt[i] = NULL;
-			}
-
-#if 0
-			if (NULL != txr_cxt_tr_nobump[i]) {
-				free(txr_cxt_tr_nobump[i]);
-				txr_cxt_tr_nobump[i] = NULL;
-			}
-#endif
-			// set to 0 so the following calls will start from scratch
-			num_pal[i] = 0;
-		}
-
-		memset(bump_txr_ptr, 0, sizeof(pvr_ptr_t) * numtextures);
-//		memset(bump_cxt, 0, sizeof(pvr_poly_cxt_t) * numtextures);
-	}
-
-	side = sides;
-	for (i = 0; i < numsides; i++, side++) {
-		P_CachePvrTexture(side->toptexture, PU_LEVEL);
-		P_CachePvrTexture(side->bottomtexture, PU_LEVEL);
-		P_CachePvrTexture(side->midtexture, PU_LEVEL);
-	}
-
-	sector = sectors;
-	for (i = 0; i < numsectors; i++, sector++) {
-		if (sector->ceilingpic >= 0) {
-			P_CachePvrTexture(sector->ceilingpic, PU_LEVEL);
-		}
-		if (sector->floorpic >= 0) {
-			P_CachePvrTexture(sector->floorpic, PU_LEVEL);
-		}
-		if (sector->flags & MS_LIQUIDFLOOR) {
-			P_CachePvrTexture(sector->floorpic + 1, PU_LEVEL);
-		}
-	}
-
-	P_Init_calls++;
-}
-
-/*
-==============================================================================
-
-							SPECIAL SPAWNING
-
-==============================================================================
-*/
-/*
-================================================================================
-= P_SpawnSpecials
-=
-= After the map has been loaded, scan for specials that
-= spawn thinkers
-=
-===============================================================================
-y*/
-
-void P_SpawnSpecials(void)
-{
-	mobj_t *mo;
-	sector_t *sector;
-	line_t *line;
-	int i, j;
-	int lump;
-
-	// Init animation aka (P_InitPicAnims)
-	lastanim = anims;
-	for (i = 0; i < MAXANIMS; i++) {
-		lump = W_GetNumForName(animdefs[i].startname);
-
-		lastanim->basepic = (lump - firsttex);
-		lastanim->tics = animdefs[i].speed;
-		lastanim->delay = animdefs[i].delay;
-		lastanim->delaycnt = lastanim->delay;
-		lastanim->isreverse = animdefs[i].isreverse;
-
-		if (animdefs[i].ispalcycle == false) {
-			lastanim->current = (lump << 4);
-			lastanim->picstart = (lump << 4);
-			lastanim->picend = (animdefs[i].frames + lump - 1) << 4;
-			lastanim->frame = 16;
-
-			// Load the following graphics for animation
-			for (j = 0; j < animdefs[i].frames; j++) {
-				W_CacheLumpNum(lump, PU_LEVEL, dec_d64);
-				lump++;
-			}
-		} else {
-			lastanim->current = (lump << 4);
-			lastanim->picstart = (lump << 4);
-			lastanim->picend = (lump << 4) |
-					   (animdefs[i].frames - 1);
-			lastanim->frame = 1;
-		}
-
-		lastanim++;
-	}
-
-	// Init Macro Variables
-	activemacro = NULL;
-	macrocounter = 0;
-	macroidx1 = 0;
-	macroidx2 = 0;
-
-	// Init special SECTORs
-	scrollfrac = 0;
-	// Restart count
-	numsectorspecials = 0;
-	sector = sectors;
-	for (i = 0; i < numsectors; i++, sector++) {
-		P_AddSectorSpecial(sector);
-		if (sector->flags & MS_SECRET) {
-			totalsecret++;
-		}
-
-		if (sector->flags &
-		    (MS_SCROLLCEILING | MS_SCROLLFLOOR | MS_SCROLLLEFT |
-		     MS_SCROLLRIGHT | MS_SCROLLUP | MS_SCROLLDOWN)) {
-			numsectorspecials++;
-		}
-	}
-
-	sectorspeciallist = (sector_t **)Z_Malloc(
-		numsectorspecials * sizeof(void *), PU_LEVEL, NULL);
-	sector = sectors;
-	for (i = 0, j = 0; i < numsectors; i++, sector++) {
-		if (sector->flags &
-		    (MS_SCROLLCEILING | MS_SCROLLFLOOR | MS_SCROLLLEFT |
-		     MS_SCROLLRIGHT | MS_SCROLLUP | MS_SCROLLDOWN)) {
-			sectorspeciallist[j] = sector;
-			j++;
-		}
-	}
-
-	// Init line EFFECTs
-	numlinespecials = 0;
-	line = lines;
-	for (i = 0; i < numlines; i++, line++) {
-		if (line->flags & (ML_SCROLLRIGHT | ML_SCROLLLEFT |
-				   ML_SCROLLUP | ML_SCROLLDOWN)) {
-			numlinespecials++;
-		}
-	}
-
-	linespeciallist = (line_t **)Z_Malloc(numlinespecials * sizeof(void *),
-					      PU_LEVEL, NULL);
-	line = lines;
-	for (i = 0, j = 0; i < numlines; i++, line++) {
-		if (line->flags & (ML_SCROLLRIGHT | ML_SCROLLLEFT |
-				   ML_SCROLLUP | ML_SCROLLDOWN)) {
-			linespeciallist[j] = line;
-			j++;
-		}
-	}
-
-	// Init Keys
-	MapBlueKeyType = it_bluecard;
-	MapYellowKeyType = it_yellowcard;
-	MapRedKeyType = it_redcard;
-	for (mo = mobjhead.next; mo != &mobjhead; mo = mo->next) {
-		if ((mo->type == MT_ITEM_BLUESKULLKEY) ||
-		    (mo->type == MT_ITEM_YELLOWSKULLKEY) ||
-		    (mo->type == MT_ITEM_REDSKULLKEY)) {
-			MapBlueKeyType = it_blueskull;
-			MapYellowKeyType = it_yellowskull;
-			MapRedKeyType = it_redskull;
-			break;
-		}
-	}
-
-	for (i = 0; i < spawncount; i++) {
-		if ((spawnlist[i].type == 40) || (spawnlist[i].type == 39) ||
-		    (spawnlist[i].type == 38)) {
-			MapBlueKeyType = it_blueskull;
-			MapYellowKeyType = it_yellowskull;
-			MapRedKeyType = it_redskull;
-			break;
-		}
-	}
-
-	// Init other misc stuff
-	D_memset(activeceilings, 0, MAXCEILINGS * sizeof(ceiling_t *));
-	D_memset(activeplats, 0, MAXPLATS * sizeof(plat_t *));
-	D_memset(buttonlist, 0, MAXBUTTONS * sizeof(button_t));
-}
-
-/*
-==============================================================================
-
-							UTILITIES
-
-==============================================================================
-*/
-
-/*================================================================== */
-/* */
-/*	Return sector_t * of sector next to current. NULL if not two-sided line */
-/* */
-/*================================================================== */
-sector_t *getNextSector(line_t *line, sector_t *sec)
-{
-	if (!(line->flags & ML_TWOSIDED)) {
-		return NULL;
-	}
-
-	if (line->frontsector == sec) {
-		return line->backsector;
-	}
-
-	return line->frontsector;
-}
-
-/*================================================================== */
-/* */
-/*	FIND LOWEST FLOOR HEIGHT IN SURROUNDING SECTORS */
-/* */
-/*================================================================== */
-fixed_t P_FindLowestFloorSurrounding(sector_t *sec)
-{
-	int i;
-	line_t *check;
-	sector_t *other;
-	fixed_t floor = sec->floorheight;
-
-	for (i = 0; i < sec->linecount; i++) {
-		check = sec->lines[i];
-		other = getNextSector(check, sec);
-		if (!other) {
-			continue;
-		}
-		if (other->floorheight < floor) {
-			floor = other->floorheight;
-		}
-	}
-	return floor;
-}
-
-/*================================================================== */
-/* */
-/*	FIND HIGHEST FLOOR HEIGHT IN SURROUNDING SECTORS */
-/* */
-/*================================================================== */
-fixed_t P_FindHighestFloorSurrounding(sector_t *sec)
-{
-	int i;
-	line_t *check;
-	sector_t *other;
-	fixed_t floor = -500 * FRACUNIT;
-
-	for (i = 0; i < sec->linecount; i++) {
-		check = sec->lines[i];
-		other = getNextSector(check, sec);
-		if (!other) {
-			continue;
-		}
-		if (other->floorheight > floor) {
-			floor = other->floorheight;
-		}
-	}
-	return floor;
-}
-
-/*================================================================== */
-/* */
-/*	FIND NEXT HIGHEST FLOOR IN SURROUNDING SECTORS */
-/* */
-/*================================================================== */
-fixed_t P_FindNextHighestFloor(sector_t *sec, int currentheight)
-{
-	int i;
-	int h;
-	int min;
-	line_t *check;
-	sector_t *other;
-	fixed_t height = currentheight;
-	fixed_t heightlist[20]; /* 20 adjoining sectors max! */
-
-	heightlist[0] = 0;
-
-	for (i = 0, h = 0; i < sec->linecount; i++) {
-		check = sec->lines[i];
-		other = getNextSector(check, sec);
-		if (!other) {
-			continue;
-		}
-		if (other->floorheight > height) {
-			heightlist[h++] = other->floorheight;
-		}
-	}
-
-	// Find lowest height in list
-	min = heightlist[0];
-	for (i = 1; i < h; i++) {
-		if (heightlist[i] < min) {
-			min = heightlist[i];
-		}
-	}
-	return min;
-}
-
-/*================================================================== */
-/* */
-/*	FIND LOWEST CEILING IN THE SURROUNDING SECTORS */
-/* */
-/*================================================================== */
-fixed_t P_FindLowestCeilingSurrounding(sector_t *sec)
-{
-	int i;
-	line_t *check;
-	sector_t *other;
-	fixed_t height = MAXINT;
-
-	for (i = 0; i < sec->linecount; i++) {
-		check = sec->lines[i];
-		other = getNextSector(check, sec);
-		if (!other) {
-			continue;
-		}
-		if (other->ceilingheight < height) {
-			height = other->ceilingheight;
-		}
-	}
-	return height;
-}
-
-/*================================================================== */
-/* */
-/*	FIND HIGHEST CEILING IN THE SURROUNDING SECTORS */
-/* */
-/*================================================================== */
-fixed_t P_FindHighestCeilingSurrounding(sector_t *sec)
-{
-	int i;
-	line_t *check;
-	sector_t *other;
-	fixed_t height = 0;
-
-	for (i = 0; i < sec->linecount; i++) {
-		check = sec->lines[i];
-		other = getNextSector(check, sec);
-		if (!other) {
-			continue;
-		}
-		if (other->ceilingheight > height) {
-			height = other->ceilingheight;
-		}
-	}
-	return height;
-}
-
-/*================================================================== */
-/* */
-/*	RETURN NEXT SECTOR # THAT LINE TAG REFERS TO */
-/* */
-/*================================================================== */
-int P_FindSectorFromLineTag(int tag, int start)
-{
-	int i;
-
-	for (i = start + 1; i < numsectors; i++) {
-		if (sectors[i].tag == tag) {
-			return i;
-		}
-	}
-	return -1;
-}
-
-/*================================================================== */
-/* */
-/*	RETURN NEXT LIGHT # THAT LINE TAG REFERS TO */
-/*	Exclusive Doom 64 */
-/* */
-/*================================================================== */
-int P_FindLightFromLightTag(int tag, int start)
-{
-	int i;
-
-	for (i = (start + 256 + 1); i < numlights; i++) {
-		if (lights[i].tag == tag) {
-			return i;
-		}
-	}
-	return -1;
-}
-
-/*================================================================== */
-/* */
-/*	RETURN TRUE OR FALSE */
-/*	Exclusive Doom 64 */
-/* */
-/*================================================================== */
-boolean P_ActivateLineByTag(int tag, mobj_t *thing)
-{
-	int i;
-	line_t *li;
-
-	li = lines;
-	for (i = 0; i < numlines; i++, li++) {
-		if (li->tag == tag) {
-			return P_UseSpecialLine(li, thing);
-		}
-	}
-	return false;
-}
-
-/*
-==============================================================================
-							EVENTS
-
-Events are operations triggered by using, crossing, or shooting special lines,
-or by timed thinkers
-==============================================================================
-*/
-
-/*
-===============================================================================
-P_UpdateSpecials
-Animate planes, scroll walls, etc
-===============================================================================
-*/
-
-#define SCROLLLIMIT (FRACUNIT * 127)
-
-void P_UpdateSpecials(void)
-{
-	anim_t *anim;
-	line_t *line;
-	sector_t *sector;
-	fixed_t speed;
-	int i;
-	int neg;
-
-	// ANIMATE FLATS AND TEXTURES GLOBALY
-	for (anim = anims; anim < lastanim; anim++) {
-		anim->delaycnt--;
-		if ((anim->delaycnt <= 0) && !(gametic & anim->tics)) {
-			anim->current += anim->frame;
-
-			if ((anim->current < anim->picstart) ||
-			    (anim->picend < anim->current)) {
-				neg = -anim->frame;
-
-				if (anim->isreverse) {
-					anim->frame = neg;
-					anim->current += neg;
-
-					if (anim->delay == 0) {
-						anim->current += neg + neg;
-					}
-				} else {
-					anim->current = anim->picstart;
-				}
-
-				anim->delaycnt = anim->delay;
-			}
-
-			textures[anim->basepic] = anim->current;
-		}
-	}
-
-	//	ANIMATE LINE SPECIALS
-	for (i = 0; i < numlinespecials; i++) {
-		line = linespeciallist[i];
-
-		if (line->flags & ML_SCROLLRIGHT) {
-			sides[line->sidenum[0]].textureoffset += FRACUNIT;
-			sides[line->sidenum[0]].textureoffset &= SCROLLLIMIT;
-		} else if (line->flags & ML_SCROLLLEFT) {
-			sides[line->sidenum[0]].textureoffset -= FRACUNIT;
-			sides[line->sidenum[0]].textureoffset &= SCROLLLIMIT;
-		}
-
-		if (line->flags & ML_SCROLLUP) {
-			sides[line->sidenum[0]].rowoffset += FRACUNIT;
-			sides[line->sidenum[0]].rowoffset &= SCROLLLIMIT;
-		} else if (line->flags & ML_SCROLLDOWN) {
-			sides[line->sidenum[0]].rowoffset -= FRACUNIT;
-			sides[line->sidenum[0]].rowoffset &= SCROLLLIMIT;
-		}
-	}
-
-	//	ANIMATE SECTOR SPECIALS
-	scrollfrac = (scrollfrac + (FRACUNIT / 2));
-
-	for (i = 0; i < numsectorspecials; i++) {
-		sector = sectorspeciallist[i];
-
-		if (sector->flags & MS_SCROLLFAST) {
-			speed = 3 * FRACUNIT;
-		} else {
-			speed = FRACUNIT;
-		}
-
-		if (sector->flags & MS_SCROLLLEFT) {
-			sector->xoffset += speed;
-		} else if (sector->flags & MS_SCROLLRIGHT) {
-			sector->xoffset -= speed;
-		}
-
-		if (sector->flags & MS_SCROLLUP) {
-			sector->yoffset -= speed;
-		} else if (sector->flags & MS_SCROLLDOWN) {
-			sector->yoffset += speed;
-		}
-	}
-
-	/* */
-	/*	DO BUTTONS */
-	/* */
-	for (i = 0; i < MAXBUTTONS; i++) {
-		if (buttonlist[i].btimer > 0) {
-			buttonlist[i].btimer -= vblsinframe[0];
-
-			if (buttonlist[i].btimer <= 0) {
-				switch (buttonlist[i].where) {
-				case top:
-					buttonlist[i].side->toptexture =
-						buttonlist[i].btexture;
-					break;
-				case middle:
-					buttonlist[i].side->midtexture =
-						buttonlist[i].btexture;
-					break;
-				case bottom:
-					buttonlist[i].side->bottomtexture =
-						buttonlist[i].btexture;
-					break;
-				}
-				S_StartSound((mobj_t *)buttonlist[i].soundorg,
-					     sfx_switch1);
-				D_memset(
-					&buttonlist[i], 0,
-					sizeof(button_t));
-			}
-		}
-	}
-}
-
-/*
-==============================================================================
-
-							UTILITIES
-
-==============================================================================
-*/
-
-// Will return a side_t* given the number of the current sector,
-// the line number, and the side (0/1) that you want.
-side_t *getSide(int currentSector, int line, int side)
-{
-	return &sides[(sectors[currentSector].lines[line])->sidenum[side]];
-}
-
-// Will return a sector_t* given the number of the current sector,
-// the line number and the side (0/1) that you want.
-sector_t *getSector(int currentSector, int line, int side)
-{
-	return sides[(sectors[currentSector].lines[line])->sidenum[side]].sector;
-}
-
-// Given the sector number and the line number, will tell you whether
-// the line is two-sided or not.
-int twoSided(int sector, int line)
-{
-	return (sectors[sector].lines[line])->flags & ML_TWOSIDED;
-}
-
-/*
-==============================================================================
-							EVENTS
-Events are operations triggered by using, crossing, or shooting special lines, 
-or by timed thinkers
-==============================================================================
-*/
-
-void P_AddSectorSpecial(sector_t *sector)
-{
-	if ((sector->flags & MS_SYNCSPECIALS) && (sector->special)) {
-		P_CombineLightSpecials(sector);
-		return;
-	}
-
-	switch (sector->special) {
-	case 0:
-		sector->lightlevel = 0;
-		break;
-
-	case 1:
-		/* FLICKERING LIGHTS */
-		P_SpawnLightFlash(sector);
-		break;
-
-	case 2:
-		/* STROBE FAST */
-		P_SpawnStrobeFlash(sector, FASTDARK);
-		break;
-
-	case 3:
-		/* STROBE SLOW */
-		P_SpawnStrobeFlash(sector, SLOWDARK);
-		break;
-
-	case 8:
-		/* GLOWING LIGHT */
-		P_SpawnGlowingLight(sector, PULSENORMAL);
-		break;
-
-	case 9:
-		P_SpawnGlowingLight(sector, PULSESLOW);
-		break;
-
-	case 11:
-		P_SpawnGlowingLight(sector, PULSERANDOM);
-		break;
-
-	case 17:
-		P_SpawnFireFlicker(sector);
-		break;
-
-	case 202:
-		P_SpawnStrobeAltFlash(sector, 3);
-		break;
-
-	case 204:
-		P_SpawnStrobeFlash(sector, 7);
-		break;
-
-	case 205:
-		P_SpawnSequenceLight(sector, true);
-		break;
-
-	case 206:
-		P_SpawnStrobeFlash(sector, 90);
-		break;
-
-	case 208:
-		P_SpawnStrobeAltFlash(sector, 6);
-		break;
-
-	case 666:
-		break;
-	}
-}
-
-/*
-==============================================================================
-P_UseSpecialLine
-Called when a thing uses a special line
-Only the front sides of lines are usable
-===============================================================================
-*/
-
-boolean P_UseSpecialLine(line_t *line, mobj_t *thing)
-{
-	player_t *player;
-	boolean ok;
-	int actionType;
-
-	actionType = SPECIALMASK(line->special);
-
-	if (actionType == 0) {
-		return false;
-	}
-
-	player = thing->player;
-
-	// Switches that other things can activate
-	if (!player) {
-		// Missiles should NOT trigger specials...
-		if (thing->flags & MF_MISSILE) {
-			return false;
-		}
-
-		if (!(line->flags & ML_THINGTRIGGER)) {
-			// never open secret doors
-			if (line->flags & ML_SECRET) {
-				return false;
-			}
-
-			// never allow a non-player mobj to use lines with these useflags
-			if (line->special & (MLU_BLUE | MLU_YELLOW | MLU_RED)) {
-				return false;
-			}
-
-			/*
-				actionType == 1 // MANUAL DOOR RAISE
-				actionType == 2 // OPEN DOOR IMPACT
-				actionType == 4 // RAISE DOOR
-				actionType == 10 // PLAT DOWN-WAIT-UP-STAY TRIGGER
-				actionType == 39 // TELEPORT TRIGGER
-				actionType == 125 // TELEPORT MONSTERONLY TRIGGER
-			*/
-
-			if (!((line->special & MLU_USE && actionType == 1) ||
-			      (line->special & MLU_CROSS &&
-			       (actionType == 4 || actionType == 10 ||
-				actionType == 39 || actionType == 125)) ||
-			      (line->special & MLU_SHOOT && actionType == 2))) {
-				return false;
-			}
-		}
-	} else {
-		// Blue Card Lock
-		if (line->special & MLU_BLUE) {
-			if (!player->cards[it_bluecard] &&
-			    !player->cards[it_blueskull]) {
-				player->message = "You need a blue key.";
-				player->messagetic = MSGTICS;
-				player->messagecolor = 0x0080ff00;
-				S_StartSound(thing, sfx_oof);
-
-				if (player == &players[0]) {
-					tryopen[MapBlueKeyType] = true;
-				}
-				return true;
-			}
-		}
-
-		// Yellow Card Lock
-		if (line->special & MLU_YELLOW) {
-			if (!player->cards[it_yellowcard] &&
-			    !player->cards[it_yellowskull]) {
-				player->message = "You need a yellow key.";
-				player->messagetic = MSGTICS;
-				player->messagecolor = 0xC4C40000;
-				S_StartSound(thing, sfx_oof);
-
-				if (player == &players[0]) {
-					tryopen[MapYellowKeyType] = true;
-				}
-
-				return true;
-			}
-		}
-
-		// Red Card Lock
-		if (line->special & MLU_RED) {
-			if (!player->cards[it_redcard] &&
-			    !player->cards[it_redskull]) {
-				player->message = "You need a red key.";
-				player->messagetic = MSGTICS;
-				player->messagecolor = 0xff404000;
-				S_StartSound(
-					thing,
-					sfx_oof);
-
-				if (player == &players[0]) {
-					tryopen[MapRedKeyType] = true;
-				}
-
-				return true;
-			}
-		}
-
-		/*
-			actionType == 90 // ARTIFACT SWITCH 1
-			actionType == 91 // ARTIFACT SWITCH 2
-			actionType == 92 // ARTIFACT SWITCH 3
-		*/
-
-		if ((actionType == 90 || actionType == 91 ||
-		     actionType == 92) &&
-		    (((player->artifacts & 1) << ((actionType + 6) & 0x1f)) ==
-		     0)) {
-			player->message =
-				"You lack the ability to activate it.";
-			player->messagetic = MSGTICS;
-			player->messagecolor = 0xC4C4C400;
-			S_StartSound(thing, sfx_oof);
-
-			return false;
-		}
-	}
-
-	if (actionType >= 256) {
-		return P_StartMacro(actionType, line, thing);
-	}
-
-	ok = false;
-
-	// do something
-	switch (SPECIALMASK(line->special)) {
-	case 1: /* Vertical Door */
-	case 31: /* Manual Door Open */
-	case 117: /* Blazing Door Raise */
-	case 118: /* Blazing Door Open */
-		EV_VerticalDoor(line, thing);
-		ok = true;
-		break;
-	case 2: /* Open Door */
-		ok = EV_DoDoor(line, DoorOpen);
-		break;
-	case 3: /* Close Door */
-		ok = EV_DoDoor(line, DoorClose);
-		break;
-	case 4: /* Raise Door */
-		ok = EV_DoDoor(line, Normal);
-		break;
-	case 5: /* Raise Floor */
-		ok = EV_DoFloor(line, raiseFloor, FLOORSPEED);
-		break;
-	case 6: /* Fast Ceiling Crush & Raise */
-		ok = EV_DoCeiling(line, fastCrushAndRaise, CEILSPEED * 2);
-		break;
-	case 8: /* Build Stairs */
-		ok = EV_BuildStairs(line, build8);
-		break;
-	case 10: /* PlatDownWaitUp */
-		ok = EV_DoPlat(line, downWaitUpStay, 0);
-		break;
-	case 16: /* Close Door 30 */
-		ok = EV_DoDoor(line, Close30ThenOpen);
-		break;
-	case 17: /* Start Light Strobing */
-		ok = EV_StartLightStrobing(line);
-		break;
-	case 19: /* Lower Floor */
-		ok = EV_DoFloor(line, lowerFloor, FLOORSPEED);
-		break;
-	case 22: /* Raise floor to nearest height and change texture */
-		ok = EV_DoPlat(line, raiseToNearestAndChange, 0);
-		break;
-	case 25: /* Ceiling Crush and Raise */
-		ok = EV_DoCeiling(line, crushAndRaise, CEILSPEED);
-		break;
-	case 30: // Raise floor to shortest texture height on either side of lines
-		ok = EV_DoFloor(line, raiseToTexture, FLOORSPEED);
-		break;
-	case 36: /* Lower Floor (TURBO) */
-		ok = EV_DoFloor(line, turboLower, FLOORSPEED * 4);
-		break;
-	case 37: /* LowerAndChange */
-		ok = EV_DoFloor(line, lowerAndChange, FLOORSPEED);
-		break;
-	case 38: /* Lower Floor To Lowest */
-		ok = EV_DoFloor(line, lowerFloorToLowest, FLOORSPEED);
-		break;
-	case 39: /* TELEPORT! */
-		EV_Teleport(line, thing);
-		ok = false;
-		break;
-	case 43: /* Lower Ceiling to Floor */
-		ok = EV_DoCeiling(line, lowerToFloor, CEILSPEED);
-		break;
-	case 44: /* Ceiling Crush */
-		ok = EV_DoCeiling(line, lowerAndCrush, CEILSPEED);
-		break;
-	case 52: /* EXIT! */
-		P_ExitLevel(); //G_ExitLevel
-		ok = true;
-		break;
-	case 53: /* Perpetual Platform Raise */
-		ok = EV_DoPlat(line, perpetualRaise, 0);
-		break;
-	case 54: /* Platform Stop */
-		ok = EV_StopPlat(line);
-		break;
-	case 56: /* Raise Floor Crush */
-		ok = EV_DoFloor(line, raiseFloorCrush, FLOORSPEED);
-		break;
-	case 57: /* Ceiling Crush Stop */
-		ok = EV_CeilingCrushStop(line);
-		break;
-	case 58: /* Raise Floor 24 */
-		ok = EV_DoFloor(line, raiseFloor24, FLOORSPEED);
-		break;
-	case 59: /* Raise Floor 24 And Change */
-		ok = EV_DoFloor(line, raiseFloor24AndChange, FLOORSPEED);
-		break;
-	case 66: /* Raise Floor 24 and change texture */
-		ok = EV_DoPlat(line, raiseAndChange, 24);
-		break;
-	case 67: /* Raise Floor 32 and change texture */
-		ok = EV_DoPlat(line, raiseAndChange, 32);
-		break;
-	case 90: /* Artifact Switch 1 */
-	case 91: /* Artifact Switch 2 */
-	case 92: /* Artifact Switch 3 */
-		ok = P_ActivateLineByTag(line->tag + 1, thing);
-		break;
-	case 93: /* Modify mobj flags */
-		ok = P_ModifyMobjFlags(line->tag, MF_NOINFIGHTING);
-		break;
-	case 94: /* Noise Alert */
-		ok = P_AlertTaggedMobj(line->tag, thing);
-		break;
-	case 100: /* Build Stairs Turbo 16 */
-		ok = EV_BuildStairs(line, turbo16);
-		break;
-	case 108: /* Blazing Door Raise (faster than TURBO!) */
-		ok = EV_DoDoor(line, BlazeRaise);
-		break;
-	case 109: /* Blazing Door Open (faster than TURBO!) */
-		ok = EV_DoDoor(line, BlazeOpen);
-		break;
-	case 110: /* Blazing Door Close (faster than TURBO!) */
-		ok = EV_DoDoor(line, BlazeClose);
-		break;
-	case 119: /* Raise floor to nearest surr. floor */
-		ok = EV_DoFloor(line, raiseFloorToNearest, FLOORSPEED);
-		break;
-	case 121: /* Blazing PlatDownWaitUpStay */
-		ok = EV_DoPlat(line, blazeDWUS, 0);
-		break;
-	case 122: /* PlatDownWaitUpStay */
-		ok = EV_DoPlat(line, upWaitDownStay, 0);
-		break;
-	case 123: /* Blazing PlatUpWaitDownStay */
-		ok = EV_DoPlat(line, blazeUWDS, 0);
-		break;
-	case 124: /* Secret EXIT */
-		P_SecretExitLevel(line->tag); //(G_SecretExitLevel)
-		ok = true;
-		break;
-	case 125: /* TELEPORT MonsterONLY */
-		if (!thing->player) {
-			EV_Teleport(line, thing);
-			ok = false;
-		}
-		break;
-	case 141: /* Silent Ceiling Crush & Raise (Demon Disposer)*/
-		ok = EV_DoCeiling(line, silentCrushAndRaise, CEILSPEED * 2);
-		break;
-	case 200: /* Set Lookat Camera */
-		ok = P_SetAimCamera(line, true);
-		break;
-	case 201: /* Set Camera */
-		ok = P_SetAimCamera(line, false);
-		break;
-	case 202: /* Invoke Dart */
-		ok = EV_SpawnTrapMissile(line, thing, MT_PROJ_DART);
-		break;
-	case 203: /* Delay Thinker */
-		P_SpawnDelayTimer(line->tag, NULL);
-		ok = true;
-		break;
-	case 204: /* Set global integer */
-		macrointeger = line->tag;
-		ok = true;
-		break;
-	case 205: /* Modify sector color */
-		P_ModifySectorColor(line, LIGHT_FLOOR, macrointeger);
-		ok = true;
-		break;
-	case 206: /* Modify sector color */
-		ok = P_ModifySectorColor(line, LIGHT_CEILING, macrointeger);
-		break;
-	case 207: /* Modify sector color */
-		ok = P_ModifySectorColor(line, LIGHT_THING, macrointeger);
-		break;
-	case 208: /* Modify sector color */
-		ok = P_ModifySectorColor(line, LIGHT_UPRWALL, macrointeger);
-		break;
-	case 209: /* Modify sector color */
-		ok = P_ModifySectorColor(line, LIGHT_LWRWALL, macrointeger);
-		break;
-	case 210: /* Modify sector ceiling height */
-		ok = EV_DoCeiling(line, customCeiling, CEILSPEED);
-		break;
-	case 212: /* Modify sector floor height */
-		ok = EV_DoFloor(line, customFloor, FLOORSPEED);
-		break;
-	case 214: /* Elevator Sector */
-		ok = EV_SplitSector(line, true);
-		break;
-	case 218: /* Modify Line Flags */
-		ok = P_ModifyLineFlags(line, macrointeger);
-		break;
-	case 219: /* Modify Line Texture */
-		ok = P_ModifyLineTexture(line, macrointeger);
-		break;
-	case 220: /* Modify Sector Flags */
-		ok = P_ModifySector(line, macrointeger, mods_flags);
-		break;
-	case 221: /* Modify Sector Specials */
-		ok = P_ModifySector(line, macrointeger, mods_special);
-		break;
-	case 222: /* Modify Sector Lights */
-		ok = P_ModifySector(line, macrointeger, mods_lights);
-		break;
-	case 223: /* Modify Sector Flats */
-		ok = P_ModifySector(line, macrointeger, mods_flats);
-		break;
-	case 224: /* Spawn Thing */
-		ok = EV_SpawnMobjTemplate(line->tag);
-		break;
-	case 225: /* Quake Effect */
-		P_SpawnQuake(line->tag);
-		ok = true;
-		break;
-	case 226: /* Modify sector ceiling height */
-		ok = EV_DoCeiling(line, customCeiling, CEILSPEED * 4);
-		break;
-	case 227: /* Modify sector ceiling height */
-		ok = EV_DoCeiling(line, customCeiling, 4096 * FRACUNIT);
-		break;
-	case 228: /* Modify sector floor height */
-		ok = EV_DoFloor(line, customFloor, FLOORSPEED * 4);
-		break;
-	case 229: /* Modify sector floor height */
-		ok = EV_DoFloor(line, customFloor, 4096 * FRACUNIT);
-		break;
-	case 230: /* Modify Line Special */
-		ok = P_ModifyLineData(line, macrointeger);
-		break;
-	case 231: /* Invoke Revenant Missile */
-		ok = EV_SpawnTrapMissile(line, thing, MT_PROJ_TRACER);
-		break;
-	case 232: /* Fast Ceiling Crush & Raise */
-		ok = EV_DoCeiling(line, crushAndRaiseOnce, CEILSPEED * 4);
-		break;
-	case 233: /* Freeze Player */
-		thing->reactiontime = line->tag;
-		ok = true;
-		break;
-	case 234: /* Change light by light tag */
-		ok = P_ChangeLightByTag(macrointeger, line->tag);
-		break;
-	case 235: /* Modify Light Data */
-		ok = P_DoSectorLightChange(macrointeger, line->tag);
-		break;
-	case 236: /* Modify platform */
-		ok = EV_DoPlat(line, customDownUp, 0);
-		break;
-	case 237: /* Modify platform */
-		ok = EV_DoPlat(line, customDownUpFast, 0);
-		break;
-	case 238: /* Modify platform */
-		ok = EV_DoPlat(line, customUpDown, 0);
-		break;
-	case 239: /* Modify platform */
-		ok = EV_DoPlat(line, customUpDownFast, 0);
-		break;
-	case 240: /* Execute random line trigger */
-		ok = P_RandomLineTrigger(line, thing);
-		break;
-	case 241: /* Split Open Sector */
-		ok = EV_SplitSector(line, false);
-		break;
-	case 242: /* Fade Out Thing */
-		ok = EV_FadeOutMobj(line->tag);
-		break;
-	case 243: /* Move and Aim Camera */
-		P_SetMovingCamera(line);
-		ok = false;
-		break;
-	case 244: /* Modify Sector Floor */
-		ok = EV_DoFloor(line, customFloorToHeight, 4096 * FRACUNIT);
-		break;
-	case 245: /* Modify Sector Ceiling */
-		ok = EV_DoCeiling(line, customCeilingToHeight, 4096 * FRACUNIT);
-		break;
-	case 246: /* Restart Macro at ID */
-		P_RestartMacro(line, macrointeger);
-		ok = false;
-		break;
-	case 247: /* Modify Sector Floor */
-		ok = EV_DoFloor(line, customFloorToHeight, FLOORSPEED);
-		break;
-	case 248: /* Suspend a macro script */
-		ok = P_SuspendMacro();
-		break;
-	case 249: /* Silent Teleport */
-		ok = EV_SilentTeleport(line, thing);
-		break;
-	case 250: /* Toggle macros on */
-		P_ToggleMacros(line->tag, true);
-		ok = true;
-		break;
-	case 251: /* Toggle macros off */
-		P_ToggleMacros(line->tag, false);
-		ok = true;
-		break;
-	case 252: /* Modify Sector Ceiling */
-		ok = EV_DoCeiling(line, customCeilingToHeight, CEILSPEED);
-		break;
-	case 253: /* Unlock Cheat Menu */
-		if (!demoplayback) {
-			FeaturesUnlocked = true;
-		}
-		ok = true;
-		break;
-	case 254: /* D64 Map33 Logo */
-		Skyfadeback = true;
-		break;
-
-	default:
-		return false;
-	}
-
-	if (ok) {
-		if (line == &macrotempline) {
-			return true;
-		}
-
-		P_ChangeSwitchTexture(line, line->special & MLU_REPEAT);
-
-		if (line->special & MLU_REPEAT) {
-			return true;
-		}
-
-		line->special = 0;
-	}
-
-	return true;
-}
-#endif

--- a/src/p_tick.c
+++ b/src/p_tick.c
@@ -281,13 +281,6 @@ void P_Start(void) // 80021C50
 extern int plasma_channel;
 extern int plasma_loop_channel;
 
-extern int lump_frame[(575 + 310)];
-extern int used_lumps[(575 + 310)];
-extern int used_lump_idx;
-extern int delidx;
-extern int donebefore;
-extern pvr_ptr_t pvr_spritecache[MAX_CACHED_SPRITES];
-
 void P_Stop(int exit) // 80021D58
 {
 	/* [d64] stop plasma buzz */

--- a/src/p_tick.c
+++ b/src/p_tick.c
@@ -313,18 +313,6 @@ void P_Stop(int exit) // 80021D58
 
 	S_ResetSound();
 
-	if (donebefore) {
-		for (int i = 0; i < (575 + 310); i++) {
-			if (used_lumps[i] != -1) {
-				pvr_mem_free(pvr_spritecache[used_lumps[i]]);
-			}
-		}
-	}
-	memset(used_lumps, 0xff, sizeof(int) * (575 + 310));
-	memset(lump_frame, 0xff, sizeof(int) * (575 + 310));
-	used_lump_idx = 0;
-	delidx = 0;
-
 	if ((demoplayback) && (exit == 8))
 		I_WIPE_FadeOutScreen();
 	else

--- a/src/r_data.c
+++ b/src/r_data.c
@@ -326,8 +326,12 @@ void R_InitSymbols(void)
 }
 
 uint8_t *pt;
+
 pvr_poly_cxt_t flush_cxt;
-pvr_poly_hdr_t flush_hdr;
+pvr_poly_hdr_t __attribute__((aligned(32))) flush_hdr;
+
+extern int lump_frame[575 + 310];
+extern int used_lumps[575 + 310];
 
 void R_InitTextures(void)
 {
@@ -360,6 +364,10 @@ void R_InitTextures(void)
 	if (!txr_hdr_nobump) {
 		I_Error("R_InitTextures: could not malloc txr_hdr_nobump* array");
 	}
+
+#define ALL_SPRITES_INDEX (575 + 310)
+	memset(used_lumps, 0xff, sizeof(int) * ALL_SPRITES_INDEX);
+	memset(lump_frame, 0xff, sizeof(int) * ALL_SPRITES_INDEX);
 
 	num_pal = (uint8_t *)malloc(numtextures);
 	pt = (uint8_t *)malloc(numtextures);

--- a/src/r_lights.c
+++ b/src/r_lights.c
@@ -37,7 +37,7 @@ static void assign_lightcolor(d64ListVert_t *v)
 {
 	if (v->lit) {
 //		uint32_t cocol = v->v->oargb;
-		float maxrgb = 1.0f;
+		float maxrgb = 1.0f; 
 		float invmrgb;
 
 		float lightingr;// =
@@ -69,7 +69,7 @@ static void assign_lightcolor(d64ListVert_t *v)
 
 		// any contribution from projectile lights
 		// we overwrite the vertex oargb with the new blended color
-		v->v->oargb = 0xff000000 |
+		v->v->oargb = 0xff000000 | 
 					((int)(lightingr) << 16) |
 					((int)(lightingg) << 8) |
 					((int)(lightingb));
@@ -115,7 +115,7 @@ static void light_vert(d64ListVert_t *v, projectile_light_t *l, unsigned c)
 
 // calculates per-vertex light contributions and normal mapping parameters
 // for a Doom wall polygon
-void light_wall_hasbump(d64Poly_t *p, int lightmask)
+void __attribute__((noinline)) light_wall_hasbump(d64Poly_t *p, int lightmask)
 {
 	int bump_applied = 0;
 	// accumulated light direction vector
@@ -129,8 +129,12 @@ void light_wall_hasbump(d64Poly_t *p, int lightmask)
 	float center_y = (p->dVerts[0].v->y + p->dVerts[3].v->y) * 0.5f;
 	float center_z = (p->dVerts[0].v->z + p->dVerts[3].v->z) * 0.5f;
 
+	unsigned first_idx = (lightmask >> 24) & 0xf;
+	unsigned last_idx = (lightmask >> 16) & 0xf;
+
 	// for every dynamic light that was generated this frame
-	for (unsigned i = 0; i < lightidx + 1; i++) {
+	//for (unsigned i = 0; i < lightidx + 1; i++) {
+	for (unsigned i = first_idx; i <= last_idx; i++) {		
 		if (((lightmask >> i) & 1) == 0) continue;
 		projectile_light_t *pl = &projectile_lights[i];
 		float dotprod;
@@ -349,15 +353,19 @@ void light_wall_hasbump(d64Poly_t *p, int lightmask)
 // calculates per-vertex light contributions
 // for a Doom wall polygon
 // with no normal mapping
-void light_wall_nobump(d64Poly_t *p, int lightmask)
+void __attribute__((noinline)) light_wall_nobump(d64Poly_t *p, int lightmask)
 {
 	// 3d center of wall
 	float center_x = (p->dVerts[0].v->x + p->dVerts[3].v->x) * 0.5f;
 	float center_y = (p->dVerts[0].v->y + p->dVerts[3].v->y) * 0.5f;
 	float center_z = (p->dVerts[0].v->z + p->dVerts[3].v->z) * 0.5f;
 
+	unsigned first_idx = (lightmask >> 24) & 0xf;
+	unsigned last_idx = (lightmask >> 16) & 0xf;
+
 	// for every dynamic light that was generated this frame
-	for (unsigned i = 0; i < lightidx + 1; i++) {
+	//for (unsigned i = 0; i < lightidx + 1; i++) {
+	for (unsigned i = first_idx; i <= last_idx; i++) {		
 		if (((lightmask >> i) & 1) == 0) continue;
 		projectile_light_t *pl = &projectile_lights[i];
 		float dotprod;
@@ -388,9 +396,14 @@ void light_wall_nobump(d64Poly_t *p, int lightmask)
 // calculates per-vertex light contributions
 // for a Doom thing (monster/decoration sprite)
 // with no normal mapping
-void light_thing(d64Poly_t *p, int lightmask)
+void __attribute__((noinline)) light_thing(d64Poly_t *p, int lightmask)
 {
-	for (unsigned i = 0; i < lightidx + 1; i++) {
+	unsigned first_idx = (lightmask >> 24) & 0xf;
+	unsigned last_idx = (lightmask >> 16) & 0xf;
+
+	// for every dynamic light that was generated this frame
+	//for (unsigned i = 0; i < lightidx + 1; i++) {
+	for (unsigned i = first_idx; i <= last_idx; i++) {		
 		if (((lightmask >> i) & 1) == 0) continue;
 		projectile_light_t *pl = &projectile_lights[i];
 		// calculate per-vertex light contribution from current light
@@ -435,7 +448,7 @@ void light_thing_use_norm(d64Poly_t *p)
 
 // calculates per-vertex light contributions and normal mapping parameters
 // for a triangle belonging to a Doom plane (floor/ceiling)
-void light_plane_hasbump(d64Poly_t *p, int lightmask)
+void __attribute__((noinline)) light_plane_hasbump(d64Poly_t *p, int lightmask)
 {
 	int bump_applied = 0;
 	// accumulated light direction vector
@@ -456,8 +469,13 @@ void light_plane_hasbump(d64Poly_t *p, int lightmask)
 						p->dVerts[2].v->z) *
 						0.333333f;
 
+	unsigned first_idx = (lightmask >> 24) & 0xf;
+	unsigned last_idx = (lightmask >> 16) & 0xf;
+	//dbgio_printf("\tfirst %u last %u\n", first_idx, last_idx);
+
 	// for every dynamic light that was generated this frame
-	for (unsigned i = 0; i < lightidx + 1; i++) {
+	//for (unsigned i = 0; i < lightidx + 1; i++) {
+	for (unsigned i = first_idx; i <= last_idx; i++) {		
 		if (((lightmask >> i) & 1) == 0) continue;
 		projectile_light_t *pl = &projectile_lights[i];
 		int visible;
@@ -599,13 +617,18 @@ void light_plane_hasbump(d64Poly_t *p, int lightmask)
 // calculates per-vertex light contributions
 // for a triangle belonging to a Doom plane (floor/ceiling)
 // with no normal mapping
-void light_plane_nobump(d64Poly_t *p, int lightmask)
+void __attribute__((noinline)) light_plane_nobump(d64Poly_t *p, int lightmask)
 {
 	// 3d center y coord of floor/ceiling triangle
 	// planes are horizontally flat, y is the same across all 3 verts
 	float center_y = p->dVerts[0].v->y;
+
+	unsigned first_idx = (lightmask >> 24) & 0xf;
+	unsigned last_idx = (lightmask >> 16) & 0xf;
+
 	// for every dynamic light that was generated this frame
-	for (int i = 0; i < lightidx + 1; i++) {
+	//for (unsigned i = 0; i < lightidx + 1; i++) {
+	for (unsigned i = first_idx; i <= last_idx; i++) {		
 		if (((lightmask >> i) & 1) == 0) continue;
 		projectile_light_t *pl = &projectile_lights[i];
 		int visible;

--- a/src/r_local.h
+++ b/src/r_local.h
@@ -127,19 +127,19 @@ typedef struct vissprite_s {
 } vissprite_t;
 
 typedef struct subsector_s {
-	sector_t *sector; //*
-	vissprite_t *vissprite; //*4
-	short numlines; //*8
-	short firstline; //*10
-	short numverts; //*12
-	short leaf; //*14
-	short drawindex; //*16
-//	short padding; //*18
-	short is_split; // 18
-	short index; // 20
-	short lit; // 22
-	fixed_t bbox[4]; // 22 + 16 = 38
-	char pad[10]; // 48 - 3 cache lines
+	sector_t *sector;		//  0 -> 4
+	vissprite_t *vissprite;		//  4 -> 8
+	short numlines;			//  8 -> 10
+	short firstline;		// 10 -> 12
+	short numverts;			// 12 -> 14
+	short leaf;			// 14 -> 16
+	short drawindex;		// 16 -> 18
+	short index;			// 18 -> 20
+	short is_split;			// 20 -> 22
+	short pad1;			// 22 -> 24
+	unsigned lit;			// 24 -> 28
+	fixed_t bbox[4];		// 28 -> 44
+	unsigned pad2;			// 44 -> 48
 } subsector_t;
 
 typedef struct seg_s {

--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -338,6 +338,8 @@ int S_SoundStatus(int seqnum)
 	return activ;
 }
 
+// from here down, if you see a 124 for volume, it used to be 127
+
 int S_StartSound(mobj_t *origin, int sound_id)
 {
 	int vol;
@@ -350,7 +352,7 @@ int S_StartSound(mobj_t *origin, int sound_id)
 				return -1;
 			}
 		} else {
-			vol = 127;
+			vol = 124;
 			pan = 64;
 		}
 
@@ -402,7 +404,7 @@ int S_AdjustSoundParams(mobj_t *listener, mobj_t *origin, int *vol, int *pan)
 
 	/* volume calculation */
 	if (approx_dist < S_CLOSE_DIST) {
-		tmpvol = 127;
+		tmpvol = 124;
 	} else {
 		/* distance effect */
 		approx_dist = -approx_dist; /* set neg */
@@ -410,8 +412,8 @@ int S_AdjustSoundParams(mobj_t *listener, mobj_t *origin, int *vol, int *pan)
 			 S_ATTENUATOR;
 	}
 
-	if (tmpvol > 127) {
-		tmpvol = 127;
+	if (tmpvol > 124) {
+		tmpvol = 124;
 	}
 	*vol = tmpvol;
 	return (tmpvol > 0);

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -467,6 +467,8 @@ static void load_all_comp_wepn_bumps(void) {
 	free(pwepnbump);
 }
 
+extern void P_FlushSprites(void);
+
 void W_ReplaceWeaponBumps(weapontype_t wepn)
 {
 	int w,h;
@@ -543,7 +545,8 @@ void W_ReplaceWeaponBumps(weapontype_t wepn)
 	}
 
 	if (w*h*4 > pvr_mem_available()) {
-		dbgio_printf("very low on vram\n");
+//		dbgio_printf("very low on vram\n");
+		P_FlushSprites();
 	}
 
 	wepnbump_txr = pvr_mem_malloc(w*h*2);

--- a/src/z_zone.c
+++ b/src/z_zone.c
@@ -27,7 +27,7 @@ memzone_t *mainzone;
 
 void *mem_heap;
 
-#define MEM_HEAP_SIZE 0x480020
+#define MEM_HEAP_SIZE 0x4C0020
 
 /*
 ========================


### PR DESCRIPTION
Some improvements have been made to add ranges to the `lit` bit-vector generated by subsec bbox/light tests.

Also, a faster `FixedDiv` approximation using floats has been implemented and used in R_BSP and the sight code to gain a few FPS without sacrificing accuracy in those circumstances.

Lastly, suggesting to enable `fastmath` compile flags by default. Added that to README.