### PR TITLE
Analog Movement Adjustment

### DIFF
--- a/src/am_main.c
+++ b/src/am_main.c
@@ -160,15 +160,15 @@ void AM_Control(player_t *player)
 	/* Analyze analog stick movement (left / right) */
 	sensitivity = (int)(((buttons & 0xff00) >> 8) << 24) >> 24;
 
-	if (sensitivity >= MAXSENSITIVITY || sensitivity <= -MAXSENSITIVITY) {
-		player->automapx += (sensitivity * scale) / 80;
+	if (sensitivity != 0) {
+		player->automapx += (sensitivity * scale) / 120;
 	}
 
 	/* Analyze analog stick movement (up / down) */
 	sensitivity = (int)((buttons) << 24) >> 24;
 
-	if (sensitivity >= MAXSENSITIVITY || sensitivity <= -MAXSENSITIVITY) {
-		player->automapy += (sensitivity * scale) / 80;
+	if (sensitivity != 0) {
+		player->automapy += (sensitivity * scale) / 120;
 	}
 
 	/* X movement */

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -1245,7 +1245,6 @@ extern const boolean FeaturesUnlocked; // 8005A7D0
 //extern int MotionBob; // [Immorpher] Motion Bob
 //extern int VideoFilter; // [GEC & Immorpher] VideoFilter
 extern int FlashBrightness; // [Immorpher] Strobe brightness adjustment
-extern int PlayDeadzone; // Adjust the analog stick deadzone
 //extern boolean Autorun; // [Immorpher] Autorun
 //extern boolean runintroduction; // [Immorpher] New introduction text
 //extern boolean StoryText; // [Immorpher] Enable story text

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -450,7 +450,6 @@ int G_PlayDemoPtr(int skill, int map) // 800049D0
 	int exit;
 	int config[13];
 	int sensitivity;
-	int deadzone;
 
 	demobuffer = demo_p;
 
@@ -468,12 +467,6 @@ int G_PlayDemoPtr(int skill, int map) // 800049D0
 
 	/* skip analog and key configuration */
 	demobuffer += 14;
-	
-	/* store player settings */
-	deadzone = PlayDeadzone;
-	
-	/* settings for demo compatibility */
-	PlayDeadzone = 10;
 
 	/* play demo game */
 	G_InitNew(skill, map, gt_single);
@@ -487,9 +480,6 @@ int G_PlayDemoPtr(int skill, int map) // 800049D0
 
 	/* restore analog m_sensitivity */
 	menu_settings.M_SENSITIVITY = sensitivity;
-	
-	/* restore player settings */
-	PlayDeadzone = deadzone;
 
 	/* free all tags except the PU_STATIC tag */
 	Z_FreeTags(mainzone, ~PU_STATIC); // (PU_LEVEL | PU_LEVSPEC | PU_CACHE)

--- a/src/i_main.c
+++ b/src/i_main.c
@@ -482,8 +482,8 @@ int I_GetControllerData(void)
 
 		// used for analog stick movement
 		// see am_main.c, p_user.c
-		last_joyx = ((cont->joyx * 3) / 4);
-		last_joyy = -((cont->joyy * 3) / 4);
+		last_joyx = cont->joyx;
+		last_joyy = cont->joyy;
 		// used for analog strafing, see p_user.c
 		last_Ltrig = cont->ltrig;
 		last_Rtrig = cont->rtrig;
@@ -501,7 +501,7 @@ int I_GetControllerData(void)
 			ret |= PAD_L_TRIG;
 		}
 		
-		ret |= (last_joyy & 0xff);
+		ret |= 0xff - (last_joyy & 0xff);
 		ret |= ((last_joyx & 0xff) << 8);
 
 		if (!in_menu && gamemap != 33) {

--- a/src/m_main.c
+++ b/src/m_main.c
@@ -136,7 +136,6 @@ char *ControlText[] = //8007517C
 #define M_TXT94 "Uncapped"
 
 #define M_TXT95 "Rumble:"
-#define M_TXT96 "Deadzone:" // Analog stick deadzone
 
 char *MenuText[] = // 8005ABA0
 	{
@@ -155,7 +154,7 @@ char *MenuText[] = // 8005ABA0
 		M_TXT84,
 		M_TXT85, M_TXT86, M_TXT87,
 		M_TXT88, M_TXT89, M_TXT90, M_TXT91,
-		M_TXT92, M_TXT93, M_TXT94, M_TXT95, M_TXT96, ""
+		M_TXT92, M_TXT93, M_TXT94, M_TXT95, ""
 	};
 
 #define NUM_MENU_TITLE 3
@@ -215,15 +214,14 @@ menuitem_t Menu_Volume[NUM_MENU_VOLUME] = // 8005AA08
 		{ 6, 82, 140 }, // Return
 	};
 
-#define NUM_MENU_MOVEMENT 6
+#define NUM_MENU_MOVEMENT 5
 menuitem_t Menu_Movement[NUM_MENU_MOVEMENT] = // [Immorpher] Movement
 	{
 		{ 52, 82, 60 }, // Motion Bob
 		{ 43, 82, 100 }, // Sensitivity
-		{ 96, 82, 140 }, // Deadzone
-		{ 12, 82, 160 }, // Autorun
-		{ 95, 82, 180 }, // Rumble
-		{ 6, 82, 200 }, // Return
+		{ 12, 82, 140 }, // Autorun
+		{ 95, 82, 160 }, // Rumble
+		{ 6, 82, 180 }, // Return
 	};
 
 #define NUM_MENU_VIDEO 5
@@ -407,7 +405,6 @@ int Display_Y = 0; // 8005A7B4
 const boolean FeaturesUnlocked = true; // 8005A7D0
 int force_filter_flush = 0;
 int FlashBrightness = 16; // [Immorpher] Strobe brightness adjustment, will need to change to float
-int PlayDeadzone = 0; // Analog stick deadzone adjustment
 
 int __attribute__((aligned(16))) ActualConfiguration[13] = // 8005A840
 	{ PAD_RIGHT,   PAD_LEFT, PAD_UP,     PAD_DOWN,	 PAD_Z_TRIG,
@@ -1841,27 +1838,6 @@ int M_MenuTicker(void)
 					return ga_nothing;
 				}
 				break;
-				
-			case 96: // Analog Stick Deadzone
-				if ((buttons ^ oldbuttons) && (buttons & PAD_RIGHT))
-				{
-					if (PlayDeadzone < 14)
-					{
-						PlayDeadzone += 2;
-						S_StartSound(NULL, sfx_switch2);
-						return ga_nothing;
-					}
-				}
-				else if ((buttons ^ oldbuttons) && (buttons & PAD_LEFT))
-				{
-				   if (PlayDeadzone > 0)
-					{
-						PlayDeadzone -= 2;
-						S_StartSound(NULL, sfx_switch2);
-						return ga_nothing;
-					}
-				}
-				break;
 
 			}
 			exit = ga_nothing;
@@ -2093,10 +2069,6 @@ void M_MovementDrawer(void) // 80009738
 				text = "Off";
 		} else {
 			text = NULL;
-		}
-		
-		if (casepos == 96) { // Deadzone
-			ST_DrawNumber(item->x + 120, item->y, PlayDeadzone >> 1, 0, text_alpha | 0xff000000, 1);
 		}
 
 		if (text)

--- a/src/p_user.c
+++ b/src/p_user.c
@@ -315,7 +315,10 @@ void P_BuildMove(player_t *player) // 80022154
 		/* Analyze analog stick movement (up / down) */
 		sensitivity = (int)((buttons) << 24) >> 24;
 
-		if ((sensitivity >= PlayDeadzone) || (sensitivity <= -PlayDeadzone)) {
+		if (sensitivity != 0 && !demoplayback) {
+			player->forwardmove += (forwardmove[1] * sensitivity) / 120;
+		} else if ((sensitivity >= 10) || (sensitivity <= -10)) // change sensitivity for N64 demo playback
+		{
 			player->forwardmove += (forwardmove[1] * sensitivity) / 80;
 		}
 	}
@@ -366,8 +369,11 @@ void P_BuildMove(player_t *player) // 80022154
 			/* Analyze analog stick movement (left / right) */
 			sensitivity = (int)(((buttons & 0xff00) >> 8) << 24) >> 24;
 
-			if ((sensitivity >= PlayDeadzone) || (sensitivity <= -PlayDeadzone)) {
-				player->sidemove += (sidemove[1] * sensitivity) / 80;
+			if (sensitivity != 0 && !demoplayback) {
+				player->sidemove += (sidemove[1] * sensitivity) / 120; 
+			} else if ((sensitivity >= 10) || (sensitivity <= -10)) // change sensitivity for N64 demo playback
+			{
+				player->sidemove += (sidemove[1] * sensitivity) / 80; 
 			}
 		}
 	} else {
@@ -385,7 +391,12 @@ void P_BuildMove(player_t *player) // 80022154
 			sensitivity = (int)(((buttons & 0xff00) >> 8) << 24) >> 24;
 			sensitivity = -sensitivity;
 
-			if ((sensitivity >= PlayDeadzone) || (sensitivity <= -PlayDeadzone)) {
+			if (sensitivity != 0 && !demoplayback) {
+				sensitivity = (((menu_settings.M_SENSITIVITY * 800) / 100) + 17) *
+								sensitivity;
+				player->angleturn += (sensitivity / 120) << 17;
+			} else if ((sensitivity >= 10) || (sensitivity <= -10)) // change sensitivity for N64 demo playback
+			{
 				sensitivity = (((menu_settings.M_SENSITIVITY * 800) / 100) + 17) *
 								sensitivity;
 				player->angleturn += (sensitivity / 80) << 17;


### PR DESCRIPTION
Movement scaling is added later on so some analog stick values are not initially lost due to integer division. The later scaling has been adjusted to be a bit more closer to the limited N64 range. Also since Dreamcast controllers do not really have drift, the deadzone has been reduced to 0 and no longer requires menu adjustment.