### PR TITLE
Kos compat updates

### DIFF
--- a/src/i_main.c
+++ b/src/i_main.c
@@ -863,11 +863,11 @@ int I_GetControllerData(void)
 		kbd = maple_dev_status(controller);
 
 		// ATTACK
-		if (kbd->cond.modifiers & (KBD_MOD_LCTRL | KBD_MOD_RCTRL))
+		if (kbd->cond.modifiers.raw & (KBD_MOD_LCTRL | KBD_MOD_RCTRL))
 			ret |= PAD_Z_TRIG;
 
 		// USE
-		if (kbd->cond.modifiers & (KBD_MOD_LSHIFT | KBD_MOD_RSHIFT))
+		if (kbd->cond.modifiers.raw & (KBD_MOD_LSHIFT | KBD_MOD_RSHIFT))
 			ret |= PAD_RIGHT_C;
 
 		for (int i = 0; i < MAX_PRESSED_KEYS; i++) {

--- a/src/i_main.c
+++ b/src/i_main.c
@@ -1421,7 +1421,7 @@ int I_SavePakSettings(doom64_settings_t *msettings)
 	if (!vmudev)
 		return PFS_ERR_NOPACK;
 
-	file_t d = fs_open(get_vmu_fn(vmudev, "doom64stg"), O_WRONLY | O_CREAT);
+	file_t d = fs_open(get_vmu_fn(vmudev, "doom64stg"), O_WRONLY | O_CREAT | O_META);
 	if (!d)
 		return PFS_ERR_ID_FATAL;
 
@@ -1480,7 +1480,7 @@ int I_SavePakFile(void)
 	if (!vmudev)
 		return PFS_ERR_NOPACK;
 
-	file_t d = fs_open(get_vmu_fn(vmudev, "doom64"), O_WRONLY);
+	file_t d = fs_open(get_vmu_fn(vmudev, "doom64"), O_WRONLY | O_META);
 	if (!d)
 		return PFS_ERR_ID_FATAL;
 
@@ -1543,7 +1543,7 @@ int I_ReadPakSettings(doom64_settings_t *msettings)
 	if (!vmudev)
 		return PFS_ERR_NOPACK;
 
-	file_t d = fs_open(get_vmu_fn(vmudev, "doom64stg"), O_RDONLY);
+	file_t d = fs_open(get_vmu_fn(vmudev, "doom64stg"), O_RDONLY | O_META);
 	if (!d)
 		return PFS_ERR_ID_FATAL;
 
@@ -1625,7 +1625,7 @@ int I_ReadPakFile(void)
 	Pak_Data = NULL;
 	Pak_Size = 0;
 
-	file_t d = fs_open(get_vmu_fn(vmudev, "doom64"), O_RDONLY);
+	file_t d = fs_open(get_vmu_fn(vmudev, "doom64"), O_RDONLY | O_META);
 	if (!d)
 		return PFS_ERR_ID_FATAL;
 
@@ -1661,7 +1661,7 @@ int I_ReadPakFile(void)
 
 	fs_close(d);
 
-	if(vmu_pkg_parse(data, &pkg) < 0) {
+	if(vmu_pkg_parse(data, size, &pkg) < 0) {
 		free(data);
 		return PFS_ERR_ID_FATAL;
 	}
@@ -1702,7 +1702,7 @@ int I_CreatePakFile(void)
 	memset(Pak_Data, 0, Pak_Size);
 	pkg.data = Pak_Data;
 
-	file_t d = fs_open(get_vmu_fn(vmudev, "doom64"), O_RDWR | O_CREAT);
+	file_t d = fs_open(get_vmu_fn(vmudev, "doom64"), O_RDWR | O_CREAT | O_META);
 	if (!d)
 		return PFS_ERR_ID_FATAL;
 


### PR DESCRIPTION
Two sets of changes to help out with compatibility whenever you might look to updating KOS.

The keyboard changes are due to the use of `cond` which is not really meant for external consumption, rather the state's modifiers should be used. It seems you're spinning your own implementation of the keyboard access going straight off the raw data and bypassing the driver, which is fine, but just more prone to breakage.

The VMU changes are due to an update to streamline `vmu_pkg` use. Now, without the `O_META` flag, if you read a file from a vmu you will not have to seek past the header just to get to the actual data, it will just read the data. The `O_META` flag allows access 'the old way' where the metadata is included.

To note, the VMU changes could also just be added in with any version of KOS and would just not make any difference. The keyboard updates could do the same as well by using the alternative of `kbd->shift_keys` rather than `cond.modifiers` (or the new `cond.modifiers.raw`) which contain the same data in them.