### PR TITLE
KOS and GCC compat updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ C_FILES := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c))
 # Object files
 O_FILES := $(foreach file,$(C_FILES),$(file:.c=.o))
 
-CFLAGS = -Wno-deprecated-declarations -Wall -Wno-implicit-fallthrough -Wformat=2
+CFLAGS = -std=gnu17 -Wno-deprecated-declarations -Wall -Wno-implicit-fallthrough -Wformat=2
 # everyone asks "HoW dO i GeT fPs On ScReEn???"
 #CFLAGS += -DDCLOCALDEV -DOSDSHOWFPS
 

--- a/src/md5.h
+++ b/src/md5.h
@@ -28,9 +28,9 @@ documentation and/or software.
 #define _SYS_MD5_H_
 /* MD5 context. */
 typedef struct MD5Context {
-  uint32 state[4];	/* state (ABCD) */
-  uint32 count[2];	/* number of bits, modulo 2^64 (lsb first) */
-  unsigned char buffer[64];	/* input buffer */
+  uint32_t state[4];        /* state (ABCD) */
+  uint32_t count[2];        /* number of bits, modulo 2^64 (lsb first) */
+  unsigned char buffer[64]; /* input buffer */
 } MD5_CTX;
 
 #include <sys/cdefs.h>

--- a/src/md5c.c
+++ b/src/md5c.c
@@ -34,14 +34,14 @@
 
 #include "md5.h"
 
-static void MD5Transform(uint32 [4], const unsigned char [64]);
+static void MD5Transform(uint32_t [4], const unsigned char [64]);
 
 /*
  * Encodes input (uint32) into output (unsigned char). Assumes len is
  * a multiple of 4.
  */
 
-static void Encode(unsigned char *output, uint32 *input, unsigned int len)
+static void Encode(unsigned char *output, uint32_t *input, unsigned int len)
 {
 	unsigned int i, j;
 
@@ -58,13 +58,13 @@ static void Encode(unsigned char *output, uint32 *input, unsigned int len)
  * a multiple of 4.
  */
 
-static void Decode(uint32 *output, const unsigned char *input, unsigned int len)
+static void Decode(uint32_t *output, const unsigned char *input, unsigned int len)
 {
 	unsigned int i, j;
 
 	for (i = 0, j = 0; j < len; i++, j += 4)
-		output[i] = ((uint32)input[j]) | (((uint32)input[j+1]) << 8) |
-		    (((uint32)input[j+2]) << 16) | (((uint32)input[j+3]) << 24);
+		output[i] = ((uint32_t)input[j]) | (((uint32_t)input[j+1]) << 8) |
+		    (((uint32_t)input[j+2]) << 16) | (((uint32_t)input[j+3]) << 24);
 }
 
 static unsigned char PADDING[64] = {
@@ -88,22 +88,22 @@ static unsigned char PADDING[64] = {
  * Rotation is separate from addition to prevent recomputation.
  */
 #define FF(a, b, c, d, x, s, ac) { \
-	(a) += F ((b), (c), (d)) + (x) + (uint32)(ac); \
+	(a) += F ((b), (c), (d)) + (x) + (uint32_t)(ac); \
 	(a) = ROTATE_LEFT ((a), (s)); \
 	(a) += (b); \
 	}
 #define GG(a, b, c, d, x, s, ac) { \
-	(a) += G ((b), (c), (d)) + (x) + (uint32)(ac); \
+	(a) += G ((b), (c), (d)) + (x) + (uint32_t)(ac); \
 	(a) = ROTATE_LEFT ((a), (s)); \
 	(a) += (b); \
 	}
 #define HH(a, b, c, d, x, s, ac) { \
-	(a) += H ((b), (c), (d)) + (x) + (uint32)(ac); \
+	(a) += H ((b), (c), (d)) + (x) + (uint32_t)(ac); \
 	(a) = ROTATE_LEFT ((a), (s)); \
 	(a) += (b); \
 	}
 #define II(a, b, c, d, x, s, ac) { \
-	(a) += I ((b), (c), (d)) + (x) + (uint32)(ac); \
+	(a) += I ((b), (c), (d)) + (x) + (uint32_t)(ac); \
 	(a) = ROTATE_LEFT ((a), (s)); \
 	(a) += (b); \
 	}
@@ -134,9 +134,9 @@ void MD5Update(MD5_CTX *context, const unsigned char *input, unsigned int inputL
 	index = (unsigned int)((context->count[0] >> 3) & 0x3F);
 
 	/* Update number of bits */
-	if ((context->count[0] += ((uint32)inputLen << 3)) < ((uint32)inputLen << 3))
+	if ((context->count[0] += ((uint32_t)inputLen << 3)) < ((uint32_t)inputLen << 3))
 		context->count[1]++;
-	context->count[1] += ((uint32)inputLen >> 29);
+	context->count[1] += ((uint32_t)inputLen >> 29);
 
 	partLen = 64 - index;
 
@@ -198,9 +198,9 @@ void MD5Final(unsigned char digest[16], MD5_CTX *context)
 /* MD5 basic transformation. Transforms state based on block. */
 static uint32_t md5_x[16];
 
-static void MD5Transform(uint32 state[4], const unsigned char block[64])
+static void MD5Transform(uint32_t state[4], const unsigned char block[64])
 {
-	uint32 a = state[0], b = state[1], c = state[2], d = state[3];
+	uint32_t a = state[0], b = state[1], c = state[2], d = state[3];
 
 	Decode (md5_x, block, 64);
 


### PR DESCRIPTION
Two small changes that should be transparent but allow compatibility with KOS master and gcc16.

[make: Set language standard to C17 with gnu extensions.](https://github.com/jnmartin84/doom64-dc/commit/607250b2248419958dc62d234001d8eb5044227b)

C23 has done away with the allowance of empty function declarations
as is used for `state_t::action()`. When building with gcc16, which
defaults to C23, this breaks compilation as C23 sees `action(void)`.

This won't change any behavior on older versions of gcc as they would
already be using this as their default language setting.

[md5: Update old BSD types to standard int types.](https://github.com/jnmartin84/doom64-dc/commit/666063543f227736e1011b76e40bcb9305c31883)

KOS used to provide these out of various headers but is slowly
moving away from them to prevent mismatching with projects that
define them locally. On KOS master, this is currently broken
due to no longer having those old types provided.